### PR TITLE
Pass arguments as a string instead of as an array

### DIFF
--- a/query
+++ b/query
@@ -18,5 +18,5 @@ if [[ ! -f "${jar}" ]]; then
 fi
 
 
-#exec java -cp "${jar}" "${app_class}" $@
-exec ./sbt "run-main tech.sourced.gemini.QueryApp $@"
+#exec java -cp "${jar}" "${app_class}" $*
+exec ./sbt "run-main tech.sourced.gemini.QueryApp $*"

--- a/report
+++ b/report
@@ -17,4 +17,4 @@ if [[ ! -f "${jar}" ]]; then
     fi
 fi
 
-exec ./sbt "run-main ${app_class} $@"
+exec ./sbt "run-main ${app_class} $*"


### PR DESCRIPTION
I realized that `report` fails when args are passed as an array (`$@`) because `exec` needs a string of args
Using `$*` the args are passed as a string