### PR TITLE
Use engine 0.3.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   lazy val spark = "org.apache.spark" %% "spark-core" % "2.2.0"
   lazy val fixNetty = "io.netty" % "netty-all" % "4.1.11.Final"
   lazy val fixNewerHadoopClient = "org.apache.hadoop" % "hadoop-client" % "2.7.2"
-  lazy val engine = "tech.sourced" % "engine" % "0.2.0" classifier "slim"
+  lazy val engine = "tech.sourced" % "engine" % "0.3.1" classifier "slim"
   lazy val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"
   lazy val cassandraSparkConnector = "com.datastax.spark" %% "spark-cassandra-connector" % "2.0.6"
   lazy val cassandraDriverMetrics = "com.codahale.metrics" % "metrics-core" % "3.0.2"

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -18,12 +18,12 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
 
   import session.implicits._
 
-  def hash(reposPath: String, limit: Int = 0): DataFrame = {
+  def hash(reposPath: String, limit: Int = 0, format: String = "siva"): DataFrame = {
     if (session == null) {
       throw new UnsupportedOperationException("Hashing requires a SparkSession.")
     }
 
-    val engine = Engine(session, reposPath)
+    val engine = Engine(session, reposPath, format)
 
     // engine.getRepositories.limit(n)...getFiles - doesn't work in engine now
     // https://github.com/src-d/engine/issues/267

--- a/src/main/scala/tech/sourced/gemini/HashSparkApp.scala
+++ b/src/main/scala/tech/sourced/gemini/HashSparkApp.scala
@@ -13,12 +13,15 @@ case class HashAppConfig(reposPath: String = "",
                          limit: Int = 0,
                          host: String = Gemini.defaultCassandraHost,
                          port: Int = Gemini.defaultCassandraPort,
+                         format: String = "siva",
                          verbose: Boolean = false)
 
 /**
   * Apache Spark app that applied LSH to given repos, using source{d} Engine.
   */
 object HashSparkApp extends App with Logging {
+  val repoFormats = Seq("siva", "bare", "standard")
+
   val parser = new scopt.OptionParser[HashAppConfig]("./hash") {
     head("Gemini Hasher")
     note("Hashes given set of Git repositories, either from FS or as .siva files.")
@@ -32,6 +35,14 @@ object HashSparkApp extends App with Logging {
     opt[Int]('l', "limit")
       .action((x, c) => c.copy(limit = x))
       .text("limit on the number of processed repositories")
+    opt[String]('f', "format")
+      .valueName(repoFormats.mkString(" | "))
+      .withFallback(() => "siva")
+      .validate(x =>
+        if (repoFormats contains x) success else failure(s"format must be one of " + repoFormats.mkString(" | "))
+      )
+      .action((x, c) => c.copy(format = x))
+      .text("format of the stored repositories")
     opt[Unit]('v', "verbose")
       .action((_, c) => c.copy(verbose = true))
       .text("producing more verbose debug output")
@@ -62,7 +73,7 @@ object HashSparkApp extends App with Logging {
       CassandraConnector(spark.sparkContext).withSessionDo { cassandra =>
         gemini.applySchema(cassandra)
       }
-      val filesToWrite = gemini.hash(reposPath, config.limit)
+      val filesToWrite = gemini.hash(reposPath, config.limit, config.format)
       gemini.save(filesToWrite)
       println("Done")
 


### PR DESCRIPTION
Originally it was needed to fix a problem with HDFS, but it also fixes important bug:
https://github.com/src-d/engine/releases/tag/v0.3.0
Now if all the siva files or standard repositories are in the same folder, they are correctly parallelized.