### PR TITLE
Refactoring: move report representation details out of API

### DIFF
--- a/report
+++ b/report
@@ -6,7 +6,7 @@ E_BUILD_FAILED=142
 jar="target/gemini-0.0.1-SNAPSHOT.jar"
 build_command="./sbt package"
 
-app_class="tech.sourced.gemini.ReportSparkApp"
+app_class="tech.sourced.gemini.ReportApp"
 
 hash java >/dev/null 2>&1 || { echo "Please install Java" >&2; exit 1; }
 

--- a/src/main/scala/tech/sourced/gemini/QueryApp.scala
+++ b/src/main/scala/tech/sourced/gemini/QueryApp.scala
@@ -46,7 +46,7 @@ object QueryApp extends App {
       val gemini = Gemini(null, log)
       gemini.applySchema(cassandra)
 
-      val similar = gemini.query(file, cassandra).v
+      val similar = gemini.query(file, cassandra)
 
       cassandra.close()
       cluster.close()

--- a/src/main/scala/tech/sourced/gemini/ReportApp.scala
+++ b/src/main/scala/tech/sourced/gemini/ReportApp.scala
@@ -4,10 +4,10 @@ import com.datastax.driver.core.Cluster
 
 case class ReportAppConfig(host: String = Gemini.defaultCassandraHost,
                            port: Int = Gemini.defaultCassandraPort,
-                           mode: String = ReportSparkApp.defaultMode,
+                           mode: String = ReportApp.defaultMode,
                            verbose: Boolean = false)
 
-object ReportSparkApp extends App {
+object ReportApp extends App {
   val defaultMode = ""
   val groupByMode = "use-group-by"
   val condensedMode = "condensed"

--- a/src/main/scala/tech/sourced/gemini/ReportApp.scala
+++ b/src/main/scala/tech/sourced/gemini/ReportApp.scala
@@ -48,9 +48,9 @@ object ReportApp extends App {
       gemini.applySchema(cassandra)
 
       val report = config.mode match {
-        case `defaultMode` => gemini.report(cassandra)
-        case `condensedMode` => gemini.reportCassandraCondensed(cassandra)
-        case `groupByMode` => gemini.reportCassandraGroupBy(cassandra)
+        case `defaultMode` => ReportExpandedGroup(gemini.report(cassandra))
+        case `condensedMode` => ReportGrouped(gemini.reportCassandraCondensed(cassandra))
+        case `groupByMode` => ReportExpandedGroup(gemini.reportCassandraGroupBy(cassandra))
       }
 
       cassandra.close()
@@ -72,5 +72,20 @@ object ReportApp extends App {
         }
     }
   }
+
+  sealed abstract class Report(v: Iterable[Any]) {
+    def empty(): Boolean = {
+      v.isEmpty
+    }
+
+    def size(): Int = v.size
+  }
+
+  case class ReportByLine(v: Iterable[RepoFile]) extends Report(v)
+
+  case class ReportGrouped(v: Iterable[DuplicateBlobHash]) extends Report(v)
+
+  case class ReportExpandedGroup(v: Iterable[Iterable[RepoFile]]) extends Report(v)
+
 
 }

--- a/src/test/scala/tech/sourced/gemini/CassandraSparkSpec.scala
+++ b/src/test/scala/tech/sourced/gemini/CassandraSparkSpec.scala
@@ -79,10 +79,10 @@ class CassandraSparkSpec extends FlatSpec
     val sha1 = gemini.query("LICENSE", session)
     println("Done")
 
-    sha1.v should not be empty
-    sha1.v.head.sha should be("097f4a292c384e002c5b5ce8e15d746849af7b37") // git hash-object -w LICENSE
-    sha1.v.head.repo should be("null/Users/alex/src-d/gemini")
-    sha1.v.head.commit should be("4aa29ac236c55ebbfbef149fef7054d25832717f")
+    sha1 should not be empty
+    sha1.head.sha should be("097f4a292c384e002c5b5ce8e15d746849af7b37") // git hash-object -w LICENSE
+    sha1.head.repo should be("null/Users/alex/src-d/gemini")
+    sha1.head.commit should be("4aa29ac236c55ebbfbef149fef7054d25832717f")
   }
 
   "Query for duplicates in single repository" should "return 2 files" in {
@@ -99,7 +99,7 @@ class CassandraSparkSpec extends FlatSpec
     val gemini = Gemini(sparkSession, logger, DUPLICATES)
 
     println("Query")
-    val report = gemini.reportCassandraCondensed(session).v
+    val report = gemini.reportCassandraCondensed(session)
     println("Done")
 
     report should have size expectedDuplicateFiles.size
@@ -110,7 +110,7 @@ class CassandraSparkSpec extends FlatSpec
     val gemini = Gemini(sparkSession, logger, DUPLICATES)
 
     println("Query")
-    val detailedReport = gemini.reportCassandraGroupBy(session).v
+    val detailedReport = gemini.reportCassandraGroupBy(session)
     println("Done")
 
     val duplicatedFileNames = detailedReport map (_.head.path)
@@ -121,7 +121,7 @@ class CassandraSparkSpec extends FlatSpec
     val gemini = Gemini(sparkSession, logger, DUPLICATES)
 
     println("Query")
-    val detailedReport = gemini.report(session).v
+    val detailedReport = gemini.report(session)
     println("Done")
 
     val duplicatedFileNames = detailedReport map (_.head.path)


### PR DESCRIPTION
Based on #65, it moves the details of report representation from API to the report class.