### PR TITLE
Add YAPF lint and format to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ MAKEFILE = Makefile.main
 CI_REPOSITORY = https://github.com/src-d/ci.git
 CI_FOLDER = .ci
 
+# Python configuration
+YAPF = yapf
+PYTHON_LINT_DIRS = src/main/python
+YAPF_CMD = $(YAPF) --recursive $(PYTHON_LINT_DIRS) --parallel --exclude '*/pb/*'
+
 $(MAKEFILE):
 	@git clone --quiet $(CI_REPOSITORY) $(CI_FOLDER); \
 	cp $(CI_FOLDER)/$(MAKEFILE) .;
@@ -16,3 +21,9 @@ $(MAKEFILE):
 build:
 	$(SBT) assembly
 	$(SBT) package
+
+format-python:
+	$(YAPF_CMD) --in-place
+
+lint-python:
+	$(YAPF_CMD) --diff

--- a/src/main/python/server.py
+++ b/src/main/python/server.py
@@ -39,8 +39,8 @@ def serve(port):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Feature Extractor Service.')
-    parser.add_argument("--port", type=int, default=9001,
-                        help="server listen port")
+    parser.add_argument(
+        "--port", type=int, default=9001, help="server listen port")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Fixes #62.

Commit 3cbbf5b adds 2 commands, `make lint-python` and `make format-python`. Both use https://github.com/google/yapf with the default style.

Commit c2dce37 simply applies the formatting to the existing code.

The lint should be added to the travis CI, but I'm not sure if we want to do it now or later when we add python tests.