### PR TITLE
Add python yapf lint to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,15 @@ matrix:
       - docker run -p 9001:9001 -e PYTHONHASHSEED=0 -d srcd/gemini-fe
       - ./sbt "test-only * -- -n tags.FEIntegration"
 
+  - scala: 2.11.2
+    env: PYTHON_LINT_TESTS=true
+    before_install:
+      - sudo apt-get -qq update
+      - sudo apt-get -y install python3-pip
+      - pip3 install --user yapf
+    script:
+      - make lint-python
+
 before_script:
  - ./scripts/start_docker_db.sh
  - ./scripts/start_docker_bblfsh.sh

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CI_FOLDER = .ci
 
 # Python configuration
 YAPF = yapf
-PYTHON_LINT_DIRS = src/main/python
+PYTHON_LINT_DIRS = src/main/python src/test/resources/weighted-minhash
 YAPF_CMD = $(YAPF) --recursive $(PYTHON_LINT_DIRS) --parallel --exclude '*/pb/*'
 
 $(MAKEFILE):

--- a/src/main/python/server.py
+++ b/src/main/python/server.py
@@ -49,8 +49,9 @@ class Service(service_pb2_grpc.FeatureExtractorServicer):
         return self._create_response(extractor.extract(request.uast))
 
     def _create_response(self, f_iter):
-        features = [service_pb2.Feature(
-            name=f[0], weight=f[1]) for f in f_iter]
+        features = [
+            service_pb2.Feature(name=f[0], weight=f[1]) for f in f_iter
+        ]
 
         return service_pb2.FeaturesReply(features=features)
 

--- a/src/main/python/test_server.py
+++ b/src/main/python/test_server.py
@@ -35,43 +35,47 @@ class TestServer(unittest.TestCase):
         self.server.stop(0)
 
     def test_Identifiers(self):
-        response = self.stub.Identifiers(service_pb2.IdentifiersRequest(
-            docfreqThreshold=5, splitStem=False, uast=self.uast))
+        response = self.stub.Identifiers(
+            service_pb2.IdentifiersRequest(
+                docfreqThreshold=5, splitStem=False, uast=self.uast))
 
         self.assertEqual(len(response.features), 49)
         self.assertEqual(response.features[0].name, 'i.sys')
         self.assertEqual(response.features[0].weight, 1)
 
     def test_Literals(self):
-        response = self.stub.Literals(service_pb2.LiteralsRequest(
-            docfreqThreshold=5, uast=self.uast))
+        response = self.stub.Literals(
+            service_pb2.LiteralsRequest(docfreqThreshold=5, uast=self.uast))
 
         self.assertEqual(len(response.features), 16)
         self.assertEqual(response.features[0].name, 'l.3b286224b098296c')
         self.assertEqual(response.features[0].weight, 1)
 
     def test_Uast2seq(self):
-        response = self.stub.Uast2seq(service_pb2.Uast2seqRequest(
-            docfreqThreshold=5, uast=self.uast))
+        response = self.stub.Uast2seq(
+            service_pb2.Uast2seqRequest(docfreqThreshold=5, uast=self.uast))
 
         self.assertEqual(len(response.features), 207)
-        self.assertEqual(
-            response.features[0].name, 's.alias>NoopLine>PreviousNoops>Import>Str')
+        self.assertEqual(response.features[0].name,
+                         's.alias>NoopLine>PreviousNoops>Import>Str')
         self.assertEqual(response.features[0].weight, 1)
 
     def test_with_weight(self):
-        response = self.stub.Identifiers(service_pb2.IdentifiersRequest(
-            docfreqThreshold=5, splitStem=False, uast=self.uast, weight=2))
+        response = self.stub.Identifiers(
+            service_pb2.IdentifiersRequest(
+                docfreqThreshold=5, splitStem=False, uast=self.uast, weight=2))
 
         self.assertEqual(response.features[0].weight, 2)
 
-        response = self.stub.Literals(service_pb2.LiteralsRequest(
-            docfreqThreshold=5, uast=self.uast, weight=2))
+        response = self.stub.Literals(
+            service_pb2.LiteralsRequest(
+                docfreqThreshold=5, uast=self.uast, weight=2))
 
         self.assertEqual(response.features[0].weight, 2)
 
-        response = self.stub.Uast2seq(service_pb2.Uast2seqRequest(
-            docfreqThreshold=5, uast=self.uast, weight=2))
+        response = self.stub.Uast2seq(
+            service_pb2.Uast2seqRequest(
+                docfreqThreshold=5, uast=self.uast, weight=2))
 
         self.assertEqual(response.features[0].weight, 2)
 

--- a/src/test/resources/weighted-minhash/weighted_minhash_test.py
+++ b/src/test/resources/weighted-minhash/weighted_minhash_test.py
@@ -6,11 +6,14 @@ import os
 
 dirname = os.path.dirname(__file__)
 
+
 def write_csv_int(name, arr):
     numpy.savetxt("%s/csv/%s" % (dirname, name), arr, fmt="%u", delimiter=",")
 
+
 def write_csv_float(name, arr):
     numpy.savetxt("%s/csv/%s" % (dirname, name), arr, delimiter=",")
+
 
 def tiny_test():
     v1 = [1, 0, 0, 0, 3, 4, 5, 0, 0, 0, 0, 6, 7, 8, 0, 0, 0, 0, 0, 0, 9, 10, 4]
@@ -25,6 +28,7 @@ def tiny_test():
     write_csv_int("tiny-data.csv", [v1, v2])
     write_csv_int("tiny-hashes-0.csv", bgen.minhash(v1).hashvalues)
     write_csv_int("tiny-hashes-1.csv", bgen.minhash(v2).hashvalues)
+
 
 def big_test():
     numpy.random.seed(0)
@@ -43,7 +47,8 @@ def big_test():
     c = 0
     for line in data:
         write_csv_int("big-hashes-%d.csv" % c, bgen.minhash(line).hashvalues)
-        c = c+1
+        c = c + 1
+
 
 os.makedirs("%s/csv" % dirname, exist_ok=True)
 


### PR DESCRIPTION
Fixes #61.

Adds a new travis job that runs `make lint-python`, and another commit that fixes current formatting.

The manual python installation is needed because travis.yml can only have one language environment, in our case scala.