### PR TITLE
Call community detector lib with parquet data

### DIFF
--- a/src/main/python/community-detector/fixtures/generator.py
+++ b/src/main/python/community-detector/fixtures/generator.py
@@ -24,18 +24,22 @@ def main():
         id_to_buckets_shape=ccsmodel.id_to_buckets.shape)
 
     if DEBUG_CSV:
-        numpy.savetxt("./csv/id_to_cc.csv", ccsmodel.id_to_cc, delimiter=",")
+        numpy.savetxt(
+            "./csv/id_to_cc.csv", ccsmodel.id_to_cc, fmt='%u', delimiter=",")
         numpy.savetxt(
             "./csv/id_to_buckets_data.csv",
             ccsmodel.id_to_buckets.data,
+            fmt='%u',
             delimiter=",")
         numpy.savetxt(
             "./csv/id_to_buckets_indices.csv",
             ccsmodel.id_to_buckets.indices,
+            fmt='%u',
             delimiter=",")
         numpy.savetxt(
             "./csv/id_to_buckets_indptr.csv",
             ccsmodel.id_to_buckets.indptr,
+            fmt='%u',
             delimiter=",")
 
     # Call 'apollo cmd', save output to communities.asdf

--- a/src/main/python/community-detector/report.py
+++ b/src/main/python/community-detector/report.py
@@ -1,0 +1,48 @@
+import argparse
+
+import numpy
+import pyarrow.parquet as pq
+
+import community_detector
+
+
+def read_connected_components(filepath):
+    dict = pq.read_table(filepath).to_pydict()
+
+    ccs = dict['cc']
+    ids = dict['element_ids']
+    return list(zip(ccs, ids))
+
+
+def read_buckets_matrix(filepath):
+    dict = pq.read_table(filepath).to_pydict()
+
+    id_to_buckets = dict['buckets']
+
+    return community_detector.build_matrix(id_to_buckets)
+
+
+def main(dirpath):
+    connected_components = read_connected_components('%s/cc.parquet' % dirpath)
+
+    buckets_matrix = read_buckets_matrix('%s/buckets.parquet' % dirpath)
+    n_ids = buckets_matrix.shape[0]
+
+    # TODO (carlosms): Scala produces a map of cc->element-id,
+    # the lib requires element-id->cc, but only to convert it
+    # to cc->element-id. Easy change once everything is working.
+    id_to_cc = community_detector.build_id_to_cc(connected_components, n_ids)
+
+    result = community_detector.detect_communities(id_to_cc, buckets_matrix)
+
+    # TODO (carlosms)
+    print(result)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Run community detection analysis.')
+    parser.add_argument('path', help='directory path of the parquet files')
+    args = parser.parse_args()
+
+    main(args.path)

--- a/src/main/python/community-detector/requirements.txt
+++ b/src/main/python/community-detector/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.14.2
+pyarrow==0.9.0
 python-igraph==0.7.1.post6
 scipy==1.0.1

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -173,14 +173,16 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
     * Return connected components from DB hashtables
     *
     * @param conn Database connections
-    * @return
+    * @return Tuple with:
+    *         - Map of connected components groupId to list of elements
+    *         - Map of element ids to list of bucket indices
     */
-  def findConnectedComponents(conn: Session): Map[Int, Set[Int]] = {
+  def findConnectedComponents(conn: Session): (Map[Int, Set[Int]], Map[Int, List[Int]]) = {
     val cc = new DBConnectedComponents(log, conn, "hashtables", keyspace)
     val buckets = cc.makeBuckets()
     val elsToBuckets = cc.elementsToBuckets(buckets)
 
-    cc.findInBuckets(buckets, elsToBuckets)
+    (cc.findInBuckets(buckets, elsToBuckets), elsToBuckets)
   }
 
   def applySchema(session: Session): Unit = {


### PR DESCRIPTION
Partially implements #60.

This PR writes extra data in `report`, and adds a new `report.py` command that reads parquet files and calls the community detector python lib.

```bash
$ ./report --keyspace apollo -o src/main/python/community-detector/parquets/
$ python src/main/python/community-detector/report.py src/main/python/community-detector/parquets
```

Next steps, to be done in future PRs:
- save the output data as a parquet file.
- make scala report app call the python command, wait for it to finish, and read the parquet data.
- use this data (possible calling the DB to get extra info) in the scala report output.

Notes:
If you look at `report.py` it would make sense to write a single parquet file with the columns `element_id, cc, buckets`. But as I put in a TODO, the community detector lib actually uses internally `cc->element-ids`. So the current `cc.parquet` could be read and used skipping `build_id_to_cc`. Left as a TODO to avoid changing too much until we have all the parts working together.