### PR TITLE
Add LICENCE file to tarball

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -680,4 +680,7 @@ BSD-style licenses
 The following components are provided under a BSD-style license. See project link for details.
 
 (BSD 3 Clause) protocol buffers (https://github.com/google/protobuf)
+  src/main/proto/google/protobuf/descriptor.proto
+
 (BSD 2 Clause) gogoprotobuf (https://github.com/gogo/protobuf)
+  src/main/proto/github.com/gogo/protobuf/gogoproto/gogo.proto

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,4 +16,5 @@ cp project/build.properties gemini-$VERSION/project/
 cp project/Dependencies.scala gemini-$VERSION/project/
 cp project/plugins.sbt gemini-$VERSION/project/
 cp -r src/main/resources/* gemini-$VERSION/src/main/resources/
+cp LICENCE gemini-$VERSION/
 tar -cvzf gemini_$VERSION.tar.gz gemini-$VERSION/


### PR DESCRIPTION
Fix: #76

There are only 2 external proto files, both of them are mentioned in LICENCE file already.