### PR TITLE
Small fixups after todays' engineering demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,13 @@ metastore_db/
 scylla
 derby.log
 .pytest_cache/
+__pycache__
 
 /Makefile.main
 /.ci
 
 scalapbc-0.7.1
 scalapbc-0.7.1.zip
+
+docfreq.json
+params.json

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Gemini [![Build Status](https://travis-ci.org/src-d/gemini.svg?branch=master)](https://travis-ci.org/src-d/gemini) [![codecov](https://codecov.io/gh/src-d/gemini/branch/master/graph/badge.svg)](https://codecov.io/gh/src-d/gemini)
 > Find similar code in Git repositories
 
-Gemini is a tool for searching for duplicate 'items' in the many source code repositories.
+Gemini is a tool for searching for similar 'items' in source code repositories.
 Supported granularity level or items are:
- - repositories (WIP)
+ - repositories (TBD)
  - files
  - functions (TBD)
 
@@ -56,6 +56,12 @@ To pre-process number of repositories for a quick finding of the duplicates run
 ```
 
 Input format of the repositories is the same as in [src-d/Engine](https://github.com/src-d/engine).
+
+**Disclamer**: Hashing for indentifing similar items is WIP and at it's current state,
+to be able to get similarity results, you need to run `apollo hash --keyspace gemini` from [Apollo](https://github.com/src-d/apollo/) first.
+
+Similarity results is an active WIP and hasing similar files in Gemini will be added next few releases.
+
 
 
 ### Query

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ parallelExecution in Test := false
 fork in Test := true //Forking is required for the Embedded Cassandra
 logBuffered in Test := false
 
+showSuccess := false
 sonatypeProfileName := "tech.sourced"
 
 // pom settings for sonatype

--- a/query
+++ b/query
@@ -19,5 +19,5 @@ fi
 
 
 #exec java -cp "${jar}" "${app_class}" $@
-exec ./sbt "run-main tech.sourced.gemini.QueryApp $*"
+exec ./sbt --warn "run-main tech.sourced.gemini.QueryApp $*"
 

--- a/report
+++ b/report
@@ -17,5 +17,7 @@ if [[ ! -f "${jar}" ]]; then
     fi
 fi
 
-exec ./sbt "run-main ${app_class} $*"
+
+#exec java -cp "${jar}" "${app_class}" $@
+exec ./sbt --warn "run-main ${app_class} $*"
 

--- a/src/main/java/tech/sourced/gemini/WeightedMinHash.java
+++ b/src/main/java/tech/sourced/gemini/WeightedMinHash.java
@@ -4,6 +4,8 @@ import org.apache.commons.math3.distribution.GammaDistribution;
 import org.apache.commons.math3.distribution.UniformRealDistribution;
 import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.random.RandomGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.Math.floor;
 import static java.lang.Math.log;
@@ -14,6 +16,8 @@ import static java.lang.Math.log;
  * https://github.com/src-d/go-license-detector/blob/master/licensedb/internal/wmh/wmh.go
  */
 public class WeightedMinHash {
+    private static final Logger log = LoggerFactory.getLogger(WeightedMinHash.class);
+
     protected int dim;
     protected int sampleSize;
 
@@ -95,6 +99,7 @@ public class WeightedMinHash {
         if (values.length != dim) {
             throw new IllegalArgumentException("input dimension mismatch, expected " + dim);
         }
+        log.info("Hashing");
 
         // hashvalues = np.zeros((self.sample_size, 2), dtype=np.int)
         long[][] hashvalues = new long[sampleSize][2];

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -15,3 +15,4 @@ log4j.logger.org.apache.cassandra.utils.CLibrary=ERROR
 log4j.logger.org.apache.cassandra.service.StartupChecks=ERROR
 log4j.logger.org.spark-project.jetty.server.Server=ERROR
 log4j.logger.org.eclipse.jetty.server.Server=ERROR
+log4j.logger.com.datastax.driver.core=ERROR

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -194,7 +194,7 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
 
   def extractUAST(file: File, client: BblfshClient): Option[Node] = {
     val byteArray = Files.readAllBytes(file.toPath)
-
+    log.info(s"Extracting UAST")
     try {
       val resp = client.parse(file.getName, new String(byteArray))
       if (resp.errors.nonEmpty) {
@@ -242,6 +242,7 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
   }
 
   def parseDocFreq(file: File): (Int, Map[String, Double], List[String]) = {
+    log.info("Reading docFreq")
     val docFreqByteArray = Files.readAllBytes(file.toPath)
     val docFreqMap = mustParseJSON[Map[_, _]](new String(docFreqByteArray))
       .asInstanceOf[Map[String, Any]]
@@ -263,6 +264,7 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
   }
 
   def parseParams(file: File): Map[String, List[List[Double]]] = {
+    log.info("Reading params")
     val paramsByteArray = Files.readAllBytes(file.toPath)
     mustParseJSON[Map[_, _]](new String(paramsByteArray))
       .asInstanceOf[Map[String, List[List[Double]]]]
@@ -286,7 +288,7 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
     }
 
     log.info(s"Bag size: ${bag.size}")
-    log.info("Hashing")
+    log.info("Started hashing file")
     log.debug(s"Bag: ${bag.mkString(",")}")
 
     // TODO don't use params file when we implement our own hash
@@ -298,7 +300,9 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
       params("ln_cs") map (_.toArray) toArray,
       params("betas") map (_.toArray) toArray)
 
-    wmh.hash(bag.toArray)
+    val hash = wmh.hash(bag.toArray)
+    log.info("Finished hashing file")
+    hash
   }
 
   /**

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -296,9 +296,9 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
     val wmh = new WeightedMinHash(
       bag.size,
       params("rs").length,
-      params("rs") map (_.toArray) toArray,
-      params("ln_cs") map (_.toArray) toArray,
-      params("betas") map (_.toArray) toArray)
+      params("rs").map(_.toArray).toArray,
+      params("ln_cs").map(_.toArray).toArray,
+      params("betas").map(_.toArray).toArray)
 
     val hash = wmh.hash(bag.toArray)
     log.info("Finished hashing file")

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -417,6 +417,8 @@ object Gemini {
   val defaultBblfshPort: Int = 9432
   val defaultFeHost: String = "127.0.0.1"
   val defaultFePort: Int = 9001
+  val defaultDocFreqFile: String = "docfreq.json"
+  val defaultParamsFile: String = "params.json"
 
   //TODO(bzz): switch to `tables("meta")`
   val meta = Meta("sha1", "repo", "commit", "path")

--- a/src/main/scala/tech/sourced/gemini/QueryApp.scala
+++ b/src/main/scala/tech/sourced/gemini/QueryApp.scala
@@ -13,10 +13,10 @@ case class QueryAppConfig(file: String = "",
                           bblfshPort: Int = Gemini.defaultBblfshPort,
                           feHost: String = Gemini.defaultFeHost,
                           fePort: Int = Gemini.defaultFePort,
-                          docFreqFile: String = "docfreq.json",
+                          docFreqFile: String = Gemini.defaultDocFreqFile,
                           // paramsFile, hashtablesNum and bandSize are needed only as long as we use apollo hash
                           // should be removed after we implement hash on our side
-                          paramsFile: String = "params.json",
+                          paramsFile: String = Gemini.defaultParamsFile,
                           hashtablesNum: Int = 0,
                           bandSize: Int = 0,
                           verbose: Boolean = false)

--- a/src/main/scala/tech/sourced/gemini/QueryApp.scala
+++ b/src/main/scala/tech/sourced/gemini/QueryApp.scala
@@ -112,7 +112,7 @@ object QueryApp extends App {
       }
 
       if (similar.isEmpty) {
-        println(s"No similar files of $file found.")
+        println(s"No similar files for $file found.")
       } else {
         println(s"Similar files of $file:\n\t" + (similar mkString "\n\t"))
       }

--- a/src/main/scala/tech/sourced/gemini/QueryApp.scala
+++ b/src/main/scala/tech/sourced/gemini/QueryApp.scala
@@ -13,10 +13,10 @@ case class QueryAppConfig(file: String = "",
                           bblfshPort: Int = Gemini.defaultBblfshPort,
                           feHost: String = Gemini.defaultFeHost,
                           fePort: Int = Gemini.defaultFePort,
-                          docFreqFile: String = "",
+                          docFreqFile: String = "docfreq.json",
                           // paramsFile, hashtablesNum and bandSize are needed only as long as we use apollo hash
                           // should be removed after we implement hash on our side
-                          paramsFile: String = "",
+                          paramsFile: String = "params.json",
                           hashtablesNum: Int = 0,
                           bandSize: Int = 0,
                           verbose: Boolean = false)
@@ -76,7 +76,7 @@ object QueryApp extends App {
       val log = Logger("gemini", config.verbose)
 
       val file = config.file
-      println(s"Query duplicate files to: $file")
+      println(s"Query duplicate files of: $file")
 
       //TODO(bzz): wrap to CassandraConnector(config).withSessionDo { session =>
       val cluster = Cluster.builder()

--- a/src/test/scala/tech/sourced/gemini/CassandraSparkSpec.scala
+++ b/src/test/scala/tech/sourced/gemini/CassandraSparkSpec.scala
@@ -143,7 +143,7 @@ class CassandraSparkSpec extends FlatSpec
     val gemini = Gemini(sparkSession, logger, DUPLICATES)
 
     // 2 file in 9279be3cf07fb3cca4fc964b27acea57e0af461b.siva
-    val sha1 = Gemini.findDuplicateItemForBlobHash("c4e5bcc8001f80acc238877174130845c5c39aa3", session, DUPLICATES)
+    val sha1 = Gemini.findDuplicatesOfBlobHash("c4e5bcc8001f80acc238877174130845c5c39aa3", session, DUPLICATES)
 
     sha1 should not be empty
     sha1.size shouldEqual 2
@@ -189,12 +189,9 @@ class CassandraSparkSpec extends FlatSpec
         9,
         13)
 
-    similar shouldBe defined
-
-    val similarV = similar.get
-    similarV.size shouldEqual 2
-    similarV(0) shouldEqual "9f653118e787febce824759bb5c4ef17fe4da7b0"
-    similarV(1) shouldEqual "e32d54ae4b969ac13f737efaf1c11ccfc52bbe5b"
+    similar.size shouldEqual 2
+    similar(0) shouldEqual "9f653118e787febce824759bb5c4ef17fe4da7b0"
+    similar(1) shouldEqual "e32d54ae4b969ac13f737efaf1c11ccfc52bbe5b"
 
     server.shutdown()
   }


### PR DESCRIPTION
Those fixes would allow for UX:

```
./query --hashtables-num 9 --band-size 13 apollo_dump_17.04/demo/files/graph.py
```

and

```
./query -v --hashtables-num 9 --band-size 13 apollo_dump_17.04/demo/files/graph.py
Query duplicate files of: apollo_dump_17.04/demo/files/graph.py
 INFO 23:16:48 tech.sourced.gemini.Gemini (Gemini.scala:197) - Extracting UAST
 INFO 23:16:49 tech.sourced.gemini.Gemini (Gemini.scala:245) - Reading docFreq
 INFO 23:16:50 tech.sourced.gemini.Gemini (Gemini.scala:290) - Bag size: 1610
 INFO 23:16:50 tech.sourced.gemini.Gemini (Gemini.scala:291) - Started hashing file
 INFO 23:16:50 tech.sourced.gemini.Gemini (Gemini.scala:267) - Reading params
 INFO 23:17:02 tech.sourced.gemini.WeightedMinHash (WeightedMinHash.java:102) - Hashing
 INFO 23:17:02 tech.sourced.gemini.Gemini (Gemini.scala:304) - Finished hashing file
 INFO 23:17:02 tech.sourced.gemini.Gemini (Gemini.scala:177) - Looking for similar items
 INFO 23:17:02 tech.sourced.gemini.Gemini (Gemini.scala:189) - Fetched 0 items
 INFO 23:17:02 tech.sourced.gemini.Gemini (Gemini.scala:113) - No similar sha1s
No duplicates of apollo_dump_17.04/demo/files/graph.py found.
No similar files for apollo_dump_17.04/demo/files/graph.py found.
```

This should allow us to demonstrate Gemini better.
