### PR TITLE
Report: use community detector lib, print similar files info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
 
   - scala: 2.11.2
     env: INTEGRATION_TESTS=true
+    before_install:
+      - ./scripts/install_python.sh
     install:
       - make build
     script:
@@ -55,6 +57,8 @@ matrix:
     env:
       - INTEGRATION_TESTS=true
       - MASTER=spark://127.0.0.1:7077
+    before_install:
+      - ./scripts/install_python.sh
     install:
       - make build
     script:
@@ -91,10 +95,7 @@ matrix:
   - scala: 2.11.2
     env: PYTHON_LIB_TESTS=true
     before_install:
-      - sudo apt-get -qq update
-      - sudo apt-get -y install python3-pip
-      - sudo pip3 install --upgrade pip setuptools wheel
-      - pip3 install --user --only-binary=numpy,scipy -r src/main/python/community-detector/requirements.txt pytest
+      - ./scripts/install_python.sh
     script:
       - pytest -v src/main/python/community-detector
 

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# A helper script to prepare the python runtime in Travis CI
+
+sudo apt-get -qq update
+sudo apt-get -y install python3-pip
+sudo pip3 install --upgrade pip setuptools wheel
+pip3 install --user --only-binary=numpy,scipy -r src/main/python/community-detector/requirements.txt pytest

--- a/src/main/python/community-detector/community_detector.py
+++ b/src/main/python/community-detector/community_detector.py
@@ -79,7 +79,7 @@ def detect_communities(cc,
         algorithm_params: Parameters for the algorithm (**kwargs, JSON format).
     
     Returns:
-        A JSON with data, indptr
+        A list of communities. Each community is a list of element-ids
     """
 
     if edges != "linear" and edges != "quadratic":
@@ -166,17 +166,7 @@ def detect_communities(cc,
               numpy.median([len(c) for c in communities]))
     log.debug("Max community size: %d", max(map(len, communities)))
 
-    # Replaces CommunitiesModel().construct(communities, ccsmodel.id_to_element).save(output)
-    size = sum(map(len, communities))
-    data = numpy.zeros(size, dtype=numpy.uint32)
-    indptr = numpy.zeros(len(communities) + 1, dtype=numpy.int64)
-    pos = 0
-    for i, community in enumerate(communities):
-        data[pos:pos + len(community)] = community
-        pos += len(community)
-        indptr[i + 1] = pos
-
-    return {"data": data, "indptr": indptr}
+    return communities
 
 
 class CommunityDetector:

--- a/src/main/python/community-detector/community_detector.py
+++ b/src/main/python/community-detector/community_detector.py
@@ -20,6 +20,9 @@ def build_matrix(id_to_buckets):
         A scipy.sparse.csr_matrix with the same contents
     """
 
+    if len(id_to_buckets) == 0:
+        return csr_matrix((0, 0), dtype=numpy.uint8)
+
     data = numpy.ones(sum(map(len, id_to_buckets)), dtype=numpy.uint8)
     indices = numpy.zeros(len(data), dtype=numpy.uint32)
     indptr = numpy.zeros(len(id_to_buckets) + 1, dtype=numpy.uint32)
@@ -159,12 +162,13 @@ def detect_communities(cc,
 
     communities.extend(chain.from_iterable((detector(g) for g in graphs)))
 
-    log.debug("Overall communities: %d", len(communities))
-    log.debug("Average community size: %.1f",
-              numpy.mean([len(c) for c in communities]))
-    log.debug("Median community size: %.1f",
-              numpy.median([len(c) for c in communities]))
-    log.debug("Max community size: %d", max(map(len, communities)))
+    if len(communities) > 0:
+        log.debug("Overall communities: %d", len(communities))
+        log.debug("Average community size: %.1f",
+                  numpy.mean([len(c) for c in communities]))
+        log.debug("Median community size: %.1f",
+                  numpy.median([len(c) for c in communities]))
+        log.debug("Max community size: %d", max(map(len, communities)))
 
     return communities
 

--- a/src/main/python/community-detector/report.py
+++ b/src/main/python/community-detector/report.py
@@ -35,11 +35,10 @@ def main(dirpath):
     id_to_cc = community_detector.build_id_to_cc(connected_components, n_ids)
 
     # The result is a list of communities. Each community is a list of element-ids
-    communities = community_detector.detect_communities(
-        id_to_cc, buckets_matrix)
-    com_ids = list(range(len(communities)))
+    coms = community_detector.detect_communities(id_to_cc, buckets_matrix)
+    com_ids = list(range(len(coms)))
 
-    data = [pa.array(com_ids), pa.array(communities)]
+    data = [pa.array(com_ids), pa.array(coms)]
     batch = pa.RecordBatch.from_arrays(data, ['community_id', 'element_ids'])
 
     table = pa.Table.from_batches([batch])

--- a/src/main/python/community-detector/report.py
+++ b/src/main/python/community-detector/report.py
@@ -1,6 +1,7 @@
 import argparse
 
 import numpy
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 import community_detector
@@ -33,10 +34,16 @@ def main(dirpath):
     # to cc->element-id. Easy change once everything is working.
     id_to_cc = community_detector.build_id_to_cc(connected_components, n_ids)
 
-    result = community_detector.detect_communities(id_to_cc, buckets_matrix)
+    # The result is a list of communities. Each community is a list of element-ids
+    communities = community_detector.detect_communities(
+        id_to_cc, buckets_matrix)
+    com_ids = list(range(len(communities)))
 
-    # TODO (carlosms)
-    print(result)
+    data = [pa.array(com_ids), pa.array(communities)]
+    batch = pa.RecordBatch.from_arrays(data, ['community_id', 'element_ids'])
+
+    table = pa.Table.from_batches([batch])
+    pq.write_table(table, '%s/communities.parquet' % dirpath)
 
 
 if __name__ == '__main__':

--- a/src/main/python/community-detector/test_community_detector.py
+++ b/src/main/python/community-detector/test_community_detector.py
@@ -25,7 +25,17 @@ class TestCommunityDetector(unittest.TestCase):
             cc = input_npz['id_to_cc']
 
         # Call community_detector
-        result = detect_communities(cc.tolist(), buckets)
+        communities = detect_communities(cc.tolist(), buckets)
+
+        # Replaces CommunitiesModel().construct(communities, ccsmodel.id_to_element).save(output)
+        size = sum(map(len, communities))
+        data = numpy.zeros(size, dtype=numpy.uint32)
+        indptr = numpy.zeros(len(communities) + 1, dtype=numpy.int64)
+        pos = 0
+        for i, community in enumerate(communities):
+            data[pos:pos + len(community)] = community
+            pos += len(community)
+            indptr[i + 1] = pos
 
         # Read npz output
         with numpy.load("%s/fixtures/output.npz" % (dirname)) as output:
@@ -33,8 +43,8 @@ class TestCommunityDetector(unittest.TestCase):
             fixture_indptr = output['indptr']
 
         # Assert equality
-        assert_array_equal(result['data'], fixture_data)
-        assert_array_equal(result['indptr'], fixture_indptr)
+        assert_array_equal(data, fixture_data)
+        assert_array_equal(indptr, fixture_indptr)
 
 
 if __name__ == '__main__':

--- a/src/main/scala/tech/sourced/gemini/ConnectedComponents.scala
+++ b/src/main/scala/tech/sourced/gemini/ConnectedComponents.scala
@@ -48,9 +48,9 @@ abstract class ConnectedComponents(log: Slf4jLogger) {
     *
     * it allows to operate with simple list of ints later instead of big ByteBuffers
     *
-    * @return
+    * @return Buckets, Element-to-ID
     */
-  def makeBuckets(): List[List[Int]] = {
+  def makeBuckets(): (List[List[Int]], Map[String, Int]) = {
     val (buckets, elementIds) = getHashtables()
       .foldLeft(List[List[Int]](), mutable.Map[String, Int]()) { (result, hashtable) =>
 
@@ -84,7 +84,7 @@ abstract class ConnectedComponents(log: Slf4jLogger) {
     log.info(s"Number of buckets: ${buckets.size}")
     log.info(s"Number of elements: ${elementIds.size}")
 
-    buckets
+    (buckets, elementIds.toMap)
   }
 
   /**

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -513,11 +513,13 @@ object Gemini {
     // Transform communities of element IDs to communities of sha1s
     // Equivalent to apollo graph.py BatchedCommunityResolver._gen_hashes
     // https://github.com/src-d/apollo/blob/f51c5a92c24cbedd54b9b30bab02f03e51fd27b3/apollo/graph.py#L295
-    val communitiesSha1 = communities.map {
-      case (communityId, community) => community.collect {
-        case id if (idToSha1.contains(id)) => idToSha1(id)
+    val communitiesSha1 = communities
+      .map { case (_, community) =>
+        community
+          .filter(idToSha1.contains)
+          .map(idToSha1)
       }
-    }.filter(_.size > 1)
+      .filter(_.size > 1)
 
 
     communitiesSha1.map(sha1s => {

--- a/src/test/scala/tech/sourced/gemini/ConnectedComponentsSpec.scala
+++ b/src/test/scala/tech/sourced/gemini/ConnectedComponentsSpec.scala
@@ -33,7 +33,7 @@ class ConnectedComponentsSpec extends FlatSpec
     val cc = new TestConnectedComponents(logger)
 
     "makeBuckets" should "correctly create buckets" in {
-      cc.makeBuckets() shouldEqual List[List[Int]](
+      cc.makeBuckets()._1 shouldEqual List[List[Int]](
         List(0, 1),
         List(2),
         List(3, 4),
@@ -47,7 +47,7 @@ class ConnectedComponentsSpec extends FlatSpec
     }
 
     "elementsToBuckets" should "create correct map" in {
-      val buckets = cc.makeBuckets()
+      val (buckets, _) = cc.makeBuckets()
       cc.elementsToBuckets(buckets) shouldEqual Map[Int, List[Int]](
         0 -> List(0, 3, 6),
         1 -> List(0),
@@ -64,7 +64,7 @@ class ConnectedComponentsSpec extends FlatSpec
     }
 
   "findInBuckets" should "return connected components" in {
-    val buckets = cc.makeBuckets()
+    val (buckets, _) = cc.makeBuckets()
     val elementToBuckets = cc.elementsToBuckets(buckets)
     cc.findInBuckets(buckets, elementToBuckets) shouldEqual Map[Int, Set[Int]](
       0 -> Set(3, 10, 7, 4),


### PR DESCRIPTION
Part of #60, this is a continuation of #90.

In `report.py` the community detection output is written to a new parquet file.
`ReportApp.scala` calls this python command and reads the new parquet file. With the communities of IDs it goes to the DB to fetch info about each file and prints it.

There is a new `scripts/install_python.sh` in order to run the report command in Travis CI.

For this PR the output is pretty simple:
```
No duplicates found.

2 similar files:
	https://github.com/whatupdave/pil/blob/f829a9c2c8d41733c3363e61d8ad9ebdae8072a1/PIL/ImageStat.py
	https://github.com/python-pillow/Pillow/blob/c013188594ba44fcd42e1adca3e4744e3983c2a0/src/PIL/ImageStat.py

2 similar files:
	https://github.com/python-pillow/Pillow/blob/c013188594ba44fcd42e1adca3e4744e3983c2a0/Tests/test_file_fitsstub.py
	https://github.com/python-pillow/Pillow/blob/c013188594ba44fcd42e1adca3e4744e3983c2a0/Tests/test_file_hdf5stub.py
```