### PR TITLE
fix dependencies + assembly deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -s $SPARK_DIR $SPARK_HOME
 
 COPY . /gemini
 
-RUN ./sbt assembly && ./sbt package
+RUN ./sbt assemblyPackageDependency && ./sbt assembly && ./sbt package
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["bash", "-c", "sleep infinity & wait"]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ $(MAKEFILE):
 -include $(MAKEFILE)
 
 build:
+	$(SBT) assemblyPackageDependency
 	$(SBT) assembly
 	$(SBT) package
 

--- a/hash
+++ b/hash
@@ -4,19 +4,26 @@
 E_NO_SPARK=2
 E_BUILD_FAILED=1
 
+version=$(grep "version :=" build.sbt | cut -d'=' -f 2 | tr -d ' ' | tr -d '"')
 jar="target/gemini-uber.jar"
 build_command="./sbt assembly"
+deps_jar="target/gemini-assembly-${version}-deps.jar"
+build_deps_command="./sbt assemblyPackageDependency"
 
 app_class="tech.sourced.gemini.HashSparkApp"
 app_name="Gemini - hashing"
 
 hash java >/dev/null 2>&1 || { echo "Please install Java" >&2; exit 1; }
 
-if [[ ! -f "${jar}" ]]; then
-    echo "${jar} not found. Running build '${build_command}'"
-    if ! $build_command ; then
+if [[ ! -f "${deps_jar}" ]]; then
+    echo "${deps_jar} not found. Running build '${build_deps_command}'"
+    if ! $build_deps_command ; then
         exit "${E_BUILD_FAILED}"
     fi
+fi
+
+if ! $build_command ; then
+    exit "${E_BUILD_FAILED}"
 fi
 
 sparkSubmit() {
@@ -39,6 +46,7 @@ sparkSubmit() {
 # spark.executor.extraJavaOptions=-Dlog4j.configuration=log4j-spark.properties
 
 sparkSubmit \
+  --jars "${deps_jar}" \
   --class "${app_class}" \
   --master "${MASTER:=local[*]}" \
   --name "${app_name}" \

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   lazy val spark = "org.apache.spark" %% "spark-core" % "2.2.0"
   lazy val fixNetty = "io.netty" % "netty-all" % "4.1.17.Final"
   lazy val fixNewerHadoopClient = "org.apache.hadoop" % "hadoop-client" % "2.7.2"
-  lazy val engine = "tech.sourced" % "engine" % "0.5.1" classifier "slim"
+  lazy val engine = "tech.sourced" % "engine" % "0.5.7" classifier "slim"
   lazy val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"
   lazy val cassandraSparkConnector = "com.datastax.spark" %% "spark-cassandra-connector" % "2.0.6"
   lazy val cassandraDriverMetrics = "com.codahale.metrics" % "metrics-core" % "3.0.2"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,5 +33,10 @@ cp feature_extractor gemini-$VERSION/
 # copy documentation
 cp LICENCE gemini-$VERSION/
 
+cat <<EOT >> gemini-$VERSION/build.sbt
+// we need it to be able to run gemini from only jar files without src
+unmanagedBase := baseDirectory.value / "target"
+EOT
+
 # create archive
 tar -cvzf gemini_$VERSION.tar.gz gemini-$VERSION/


### PR DESCRIPTION
Multiple (but related to each other) changes:

- split 1 fat jar into 2 jars:
  - one with all external dependencies
  - another one with gemini itself
- update `./hash` script to support deps jar
- `target` directory must be managed, otherwise, `assembly` would try to include old build results in a produced jar. Set it as unmanaged only in the release tarball
- remove MergeStrategy rules for scalapb and protobuf. After we added bblfsh client, the old client from engine gets evicted and there are no conflicts.
- add shading for `com.google.common` and `com.google.protobuf`, because spark also contains this packages but older versions.
- add rename for `com.trueaccord.scalapb`. Bblfsh client from engine got evicted, but engine itself have references for `com.trueaccord.scalapb`. In newer version of scalapb the package was renamed. (but fully compatible with previous one)
- update engine to the last version