### PR TITLE
Speedup CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 scala:
    - 2.11.2
@@ -14,20 +15,25 @@ matrix:
   fast_finish: true
   include:
   - scala: 2.11.2
+    before_install:
+    - ./scripts/start_docker_db.sh
     script:
-      - sleep 10 # wait for it doesn't work, port is avalable but scyllaDB is still down
       - tar -xzf src/test/resources/weighted-minhash/csv.tar.gz -C src/test/resources/weighted-minhash/
       - ./sbt "test-only * -- -l tags.FEIntegration"
 
   - scala: 2.11.2
     env: INTEGRATION_TESTS=true
     before_install:
+      - ./scripts/start_docker_db.sh
+      - ./scripts/start_docker_bblfsh.sh
       - ./scripts/install_python.sh
+      - ./scripts/get_apache_spark.sh "2.2.0" "2.7" || travis_terminate 1
     install:
       - make build
     script:
-      - ./scripts/get_apache_spark.sh "2.2.0" "2.7" || travis_terminate 1
-      - sleep 10 # wait for it doesn't work, port is avalable but scyllaDB is still down
+      # start dependencies
+      - VIRTUAL_ENV=None IN_BACKGROUND=1 ./feature_extractor
+      # just check that commands don't fail
       - ./hash src/test/resources/siva || travis_terminate 1
       - ./query ./src/test/resources/LICENSE
       - ./report
@@ -59,18 +65,16 @@ matrix:
       - MASTER=spark://127.0.0.1:7077
     before_install:
       - ./scripts/install_python.sh
+      - ./scripts/start_docker_db.sh
+      - ./scripts/start_docker_bblfsh.sh
+      - ./scripts/get_apache_spark.sh "2.2.0" "2.7" || travis_terminate 1
     install:
       - make build
-      - 
     script:
       # start dependencies
-      - ./scripts/get_apache_spark.sh "2.2.0" "2.7" || travis_terminate 1
       - ./scripts/start_apache_spark_cluster.sh "127.0.0.1" "7077" || travis_terminate 1
-      # python will be installed after https://github.com/src-d/gemini/issues/60
-      # and after merge https://github.com/src-d/gemini/pull/98 we can use local fe runner
-      - docker build -t srcd/gemini-fe -f FE.Dockerfile .
-      - ./scripts/start_docker_fe.sh
-      - sleep 10 # wait for it doesn't work, port is avalable but scyllaDB is still down
+      - VIRTUAL_ENV=None IN_BACKGROUND=1 ./feature_extractor
+      # hashing test repositories
       - ./hash src/test/resources/siva || travis_terminate 1
       # query without similarity
       - ./query ./src/test/resources/LICENSE
@@ -120,16 +124,21 @@ matrix:
     script:
       - pytest -v src/main/python/community-detector
 
-before_script:
- - ./scripts/start_docker_db.sh
- - ./scripts/start_docker_bblfsh.sh
-
 after_failure:
  - docker logs db
+
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+  # make bblfsh images readable
+  - sudo chmod -R 777 $HOME/bblfsh-drivers/images
 
 cache:
   directories:
     - .spark-dist
-    - /home/travis/.sbt
-    - /home/travis/.ivy2
-    - /home/travis/bblfsh-drivers
+    - $HOME/.sbt
+    - $HOME/.ivy2/cache
+    - $HOME/.coursier
+    - $HOME/bblfsh-drivers/images
+    - $HOME/.cache/pip/wheels

--- a/feature_extractor
+++ b/feature_extractor
@@ -12,5 +12,12 @@ if [ -z "$VIRTUAL_ENV" ]; then
     exit 1
 fi
 
-pip install --no-cache-dir -r "${service_dir}/requirements.txt"
-(cd "${service_dir}"; PYTHONHASHSEED=0 python3 server.py "$@")
+pip3 install -I --user -r "${service_dir}/requirements.txt"
+(
+    cd "${service_dir}"
+    if [ -z "$IN_BACKGROUND" ]; then
+        PYTHONHASHSEED=0 python3 server.py "$@"
+    else
+        PYTHONHASHSEED=0 python3 server.py "$@" &
+    fi
+)

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -3,6 +3,8 @@
 # A helper script to prepare the python runtime in Travis CI
 
 sudo apt-get -qq update
-sudo apt-get -y install python3-pip
-sudo pip3 install --upgrade pip setuptools wheel
-pip3 install --user --only-binary=numpy,scipy -r src/main/python/community-detector/requirements.txt pytest
+# libsnappy is needed for sourced-ml
+sudo apt-get --no-install-recommends -y install python3-pip libsnappy1 libsnappy-dev
+# pip==9.0.1 same version as sourced-ml uses
+sudo pip3 install --upgrade pip==9.0.1 setuptools wheel
+pip3 install -I --user --only-binary=numpy,scipy -r src/main/python/community-detector/requirements.txt pytest

--- a/scripts/start_docker_bblfsh.sh
+++ b/scripts/start_docker_bblfsh.sh
@@ -8,19 +8,20 @@ image="bblfsh/bblfshd:v2.4.2"
 
 set -ev
 
-if [[ -z "${STYLE_CHECK}" ]]; then
-  echo "Starting Docker image ${image}"
-  mkdir -p $HOME/bblfsh-drivers
-  docker run -v $HOME/bblfsh-drivers:/var/lib/bblfshd --name bblfshd --privileged -p 9432:9432 -d "${image}"
+echo "Starting Docker image ${image}"
+mkdir -p $HOME/bblfsh-drivers
+docker run -v $HOME/bblfsh-drivers:/var/lib/bblfshd --name bblfshd --privileged -p 9432:9432 -d "${image}"
 
-  if [[ "$?" -ne 0 ]]; then
-    echo "Unable to start Docker ${file_list}" >&2
-    exit "${E_BAD_DOCKER}"
-  fi
+if [[ "$?" -ne 0 ]]; then
+  echo "Unable to start Docker ${file_list}" >&2
+  exit "${E_BAD_DOCKER}"
+fi
 
-  docker exec -it bblfshd bblfshctl driver install --recommended
-else
-  echo "Skip starting Docker image ${image}"
+docker exec -it bblfshd bblfshctl driver install --recommended
+
+if [[ "$?" -ne 0 ]]; then
+  echo "Unable to install bblfish drivers" >&2
+  exit "${E_BAD_DOCKER}"
 fi
 
 docker ps

--- a/scripts/start_docker_db.sh
+++ b/scripts/start_docker_db.sh
@@ -8,18 +8,14 @@ image="scylladb/scylla:2.0.0"
 
 set -ev
 
-if [[ -z "${STYLE_CHECK}" ]]; then
-  echo "Starting Docker image ${image}"
-  docker run --name db -p 9042:9042 -d "${image}" \
-    --broadcast-address 127.0.0.1 --listen-address 0.0.0.0 --broadcast-rpc-address 127.0.0.1 \
-    --memory 2G --smp 1
+echo "Starting Docker image ${image}"
+docker run --name db -p 9042:9042 -d "${image}" \
+  --broadcast-address 127.0.0.1 --listen-address 0.0.0.0 --broadcast-rpc-address 127.0.0.1 \
+  --memory 2G --smp 1
 
-  if [[ "$?" -ne 0 ]]; then
-    echo "Unable to start Docker ${file_list}" >&2
-    exit "${E_BAD_DOCKER}"
-  fi
-else
-  echo "Skip starting Docker image ${image}"
+if [[ "$?" -ne 0 ]]; then
+  echo "Unable to start Docker ${file_list}" >&2
+  exit "${E_BAD_DOCKER}"
 fi
 
 docker ps

--- a/scripts/start_docker_fe.sh
+++ b/scripts/start_docker_fe.sh
@@ -8,16 +8,12 @@ image="srcd/gemini-fe"
 
 set -ev
 
-if [[ -z "${STYLE_CHECK}" ]]; then
-  echo "Starting Docker image ${image}"
-  docker run --name fe -e PYTHONHASHSEED=0 -p 9001:9001 -d "${image}"
+echo "Starting Docker image ${image}"
+docker run --name fe -e PYTHONHASHSEED=0 -p 9001:9001 -d "${image}"
 
-  if [[ "$?" -ne 0 ]]; then
-    echo "Unable to start Docker ${file_list}" >&2
-    exit "${E_BAD_DOCKER}"
-  fi
-else
-  echo "Skip starting Docker image ${image}"
+if [[ "$?" -ne 0 ]]; then
+  echo "Unable to start Docker ${file_list}" >&2
+  exit "${E_BAD_DOCKER}"
 fi
 
 docker ps


### PR DESCRIPTION
Fixes: #107 

the time, of course, depends on the network. But.

Master:
<img width="959" alt="master" src="https://user-images.githubusercontent.com/406916/39205779-f20cf6fa-47fb-11e8-8fcd-7bc4c5b1647e.png">

No cache:
<img width="958" alt="no-cache" src="https://user-images.githubusercontent.com/406916/39205794-fd515376-47fb-11e8-94a1-c70132e592e9.png">

Cached:
<img width="957" alt="cached" src="https://user-images.githubusercontent.com/406916/39205797-01ade3ee-47fc-11e8-9e24-3cc2131604a1.png">


**Details:**

ubuntu trusty doesn't have packages for python3 that we need :(

python deps: ~25s
scala build time: ~150s now. Locally it's even slower
python deps for fe instead of docker: ~35s
db starts very slow ~1m.
no more travis cache update if there is nothing to change

pip http requests have an expiration time, so it's faster to download them again than rebuild&upload travis cache every time.

**Conclusion:**
It might be possible to improve time for python dependencies (reduce 1min), but everything else works almost as fast as possible.