### PR TITLE
(almost) single command for gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,28 +59,9 @@ Local directories `repositories` and `query` are available as `/repositories` an
 Examples:
 
 ```bash
-$ docker-compose exec gemini ./hash /repositories
-Hashing 2 repositories in: /repositories
-	file:/repositories/f281ab6f2e0e38dcc3af05360667d8f530c00103.siva
-	file:/repositories/9279be3cf07fb3cca4fc964b27acea57e0af461b.siva
-Done
-
-$ docker-compose exec gemini ./query /query/consumer.go
-Query duplicate files of: /query/consumer.go
-Duplicates of /query/consumer.go:
-	https://github.com/src-d/borges/blob/e784f9d5f59d5c081c5f8f71b6c517918b899df0/consumer.go
-Similar files of /query/consumer.go:
-	https://github.com/erizocosmico/borges/blob/b1fcd3bf0ba810c05cb418babc09cc7f7783cc03/consumer.go
-
-$ docker-compose exec gemini ./report
-2 duplicates:
-	https://github.com/erizocosmico/borges/blob/b1fcd3bf0ba810c05cb418babc09cc7f7783cc03/model_test.go
-	https://github.com/src-d/borges/blob/e784f9d5f59d5c081c5f8f71b6c517918b899df0/model_test.go
-...
-2 similar files:
-	https://github.com/erizocosmico/borges/blob/b1fcd3bf0ba810c05cb418babc09cc7f7783cc03/consumer_test.go
-	https://github.com/src-d/borges/blob/e784f9d5f59d5c081c5f8f71b6c517918b899df0/consumer_test.go
-...
+docker-compose exec gemini ./hash /repositories
+docker-compose exec gemini ./query /query/consumer.go
+docker-compose exec gemini ./report
 ```
 
 

--- a/docker-compose.host.yml
+++ b/docker-compose.host.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  gemini:
+    network_mode: "host"
+
+  scylla:
+    ports:
+      - "9042:9042"
+
+  feature_extractor:
+    ports:
+      - "9001:9001"
+
+  bblfshd:
+    ports:
+      - "9432:9432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,13 @@ services:
     build: .
     volumes:
       - ./repositories:/repositories
-    network_mode: "host"
+    environment:
+      DB_HOST: scylla
+      BBLFSH_HOST: bblfshd
+      FE_HOST: featurext
 
   scylla:
     image: scylladb/scylla:2.0.0
-    ports:
-      - "9042:9042"
     volumes:
       - db-data:/var/lib/scylla
     command:
@@ -22,9 +23,7 @@ services:
       - "--memory"
       - "2G"
 
-  feature_extractor:
-    ports:
-      - "9001:9001"
+  featurext:
     build:
       context: .
       dockerfile: FE.Dockerfile
@@ -34,8 +33,6 @@ services:
   bblfshd:
     image: bblfsh/bblfshd:v2.4.2
     privileged: true
-    ports:
-      - "9432:9432"
     volumes:
       - bblfsh-storage:/var/lib/bblfshd
     entrypoint: ["/bin/sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     volumes:
       - ./repositories:/repositories
+      - ./query:/query
     environment:
       DB_HOST: scylla
       BBLFSH_HOST: bblfshd

--- a/hash
+++ b/hash
@@ -9,6 +9,7 @@ jar="target/gemini-uber.jar"
 build_command="./sbt assembly"
 deps_jar="target/gemini-assembly-${version}-deps.jar"
 build_deps_command="./sbt assemblyPackageDependency"
+current_dir="$(dirname "$0")"
 
 app_class="tech.sourced.gemini.HashSparkApp"
 app_name="Gemini - hashing"
@@ -45,6 +46,8 @@ sparkSubmit() {
 # https://issues.apache.org/jira/browse/SPARK-16784
 # spark.executor.extraJavaOptions=-Dlog4j.configuration=log4j-spark.properties
 
+source "$current_dir/scripts/common_params.sh"
+
 sparkSubmit \
   --jars "${deps_jar}" \
   --class "${app_class}" \
@@ -54,5 +57,5 @@ sparkSubmit \
   --conf "spark.default.parallelism=8" \
   --driver-java-options "-Dlog4j.configuration=jar:file:${jar}!/log4j.properties" \
   "${jar}" \
-  "$@"
+  "${COMMAND_PARAMS[@]}"
 

--- a/query
+++ b/query
@@ -6,6 +6,7 @@ E_BUILD_FAILED=142
 version=$(grep "version :=" build.sbt | cut -d'=' -f 2 | tr -d ' ' | tr -d '"')
 jar="target/gemini-${version}.jar"
 build_command="./sbt package"
+current_dir="$(dirname "$0")"
 
 app_class="tech.sourced.gemini.QueryApp"
 
@@ -18,7 +19,7 @@ if [[ ! -f "${jar}" ]]; then
     fi
 fi
 
+source "$current_dir/scripts/common_params.sh"
 
 #exec java -cp "${jar}" "${app_class}" $@
-exec ./sbt --warn "run-main tech.sourced.gemini.QueryApp $*"
-
+exec ./sbt --warn "run-main ${app_class} ${COMMAND_PARAMS[*]}"

--- a/report
+++ b/report
@@ -6,6 +6,7 @@ E_BUILD_FAILED=142
 version=$(grep "version :=" build.sbt | cut -d'=' -f 2 | tr -d ' ' | tr -d '"')
 jar="target/gemini-${version}.jar"
 build_command="./sbt package"
+current_dir="$(dirname "$0")"
 
 app_class="tech.sourced.gemini.ReportApp"
 
@@ -20,7 +21,7 @@ if [[ ! -f "${jar}" ]]; then
     fi
 fi
 
+source "$current_dir/scripts/common_params.sh"
 
 #exec java -cp "${jar}" "${app_class}" $@
-exec ./sbt --warn "run-main ${app_class} $*"
-
+exec ./sbt --warn "run-main ${app_class} ${COMMAND_PARAMS[*]}"

--- a/scripts/common_params.sh
+++ b/scripts/common_params.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Parse parameters for dependencies or use environment variable
+#
+# List of params is common for all commands:
+# Database: DB_HOST/DB_PORT
+# Bblfshd: BBLFSH_HOST/BBLFSH_PORT
+# Feature extractor: FE_HOST/FE_PORT
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+# read arguments and override variable
+case $key in
+    -h|--host)
+    DB_HOST="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -p|--port)
+    DB_PORT="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --bblfsh-host)
+    BBLFSH_HOST="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --bblfsh-port)
+    BBLFSH_PORT="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --features-extractor-host)
+    FE_HOST="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --features-extractor-port)
+    FE_PORT="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+# construct params to pass to sbt
+COMMAND_PARAMS=()
+if [ -n "$DB_HOST" ]; then COMMAND_PARAMS+=("--host" "$DB_HOST"); fi
+if [ -n "$DB_PORT" ]; then COMMAND_PARAMS+=("--port" "$DB_PORT"); fi
+# report doesn't need bblfsh or fe
+if [[ ! $0 = *"report"* ]]; then
+    if [ -n "$BBLFSH_HOST" ]; then COMMAND_PARAMS+=("--bblfsh-host" "$BBLFSH_HOST"); fi
+    if [ -n "$BBLFSH_PORT" ]; then COMMAND_PARAMS+=("--bblfsh-port" "$BBLFSH_PORT"); fi
+    if [ -n "$FE_HOST" ]; then COMMAND_PARAMS+=("--features-extractor-host" "$FE_HOST"); fi
+    if [ -n "$FE_PORT" ]; then COMMAND_PARAMS+=("--features-extractor-port" "$FE_PORT"); fi
+fi
+
+COMMAND_PARAMS+=("${POSITIONAL[@]}")


### PR DESCRIPTION
In this PR:

- update `HashSparkApp` to accept keyspace/bblfsh address/features extractor address same as `query` does
- update bash scripts to read connect parameters from env vars.
- update default `docker-compose` to use internal network
- move host port bindings to separate `docker-compose`
- update README with instruction how to run gemini using docker-compose. (other sections **AREN'T UPDATED**, it will be done in separate PR)