### PR TITLE
update CLI arguments documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ For `query` and `hash` commands parameters for bblfsh/features extractor  config
 
 Hash command specific arguments:
 
- * `-l/--limit` - limit on the number of processed repositories, no default
- * `-f/--format [siva | bare | standard]` - format of the stored repositories, default `siva`
+ * `-l/--limit` - limit the number of repositories to be processed. All repositories will be processed by default
+ * `-f/--format` - format of the stored repositories. Supported input data formats that repositories could be stored in are `siva`, `bare` or `standard`, default `siva`
 
 # Dev
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,24 @@ MASTER="spark://<spark-master-url>" ./hash <path>
 
 ### CLI arguments
 
-```
- --db <url to Cassandra>, default localhost:9042
-```
+All three commands accept parameters for database connection and logging:
+
+ * `-h/--host` - cassandra/scylla db hostname, default `127.0.0.1`
+ * `-p/--port` - cassandra/scylla db port, default `9042`
+ * `-k/--keyspace` - cassandra/scylla db keyspace, default `hashes`
+ * `-v/--verbose` - producing more verbose output, default `false`
+
+For `query` and `hash` commands parameters for bblfsh/features extractor  configuration are available:
+
+ * `--bblfsh-host` - babelfish server host, default `127.0.0.1`
+ * `--bblfsh-port` - babelfish server port, default `9432`
+ * `--features-extractor-host` - features-extractor host, default `127.0.0.1`
+ * `--features-extractor-port` - features-extractor port, default `9001`
+
+Hash command specific arguments:
+
+ * `-l/--limit` - limit on the number of processed repositories, no default
+ * `-f/--format [siva | bare | standard]` - format of the stored repositories, default `siva`
 
 # Dev
 


### PR DESCRIPTION
This PR documents CLI arguments.

Some internal arguments such as docfreq file path or connected components output dir left undocumented on purpose.

There is also `mode` argument for report, but I don't really understand why we need it and it's not going to work by default. (default DB is scylla, not Cassandra for now) So I left it undocumented too.