### PR TITLE
Hash: switch logging to WARN by default

### DIFF
--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -30,7 +30,7 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
     if (session == null) {
       throw new UnsupportedOperationException("Hashing requires a SparkSession.")
     }
-    log.info(s"Getting repositories at $reposPath in $format format")
+    log.warn(s"Getting repositories at $reposPath in $format format")
 
     // hash might be called more than one time with the same spark session
     // every run should re-process all repos/files
@@ -39,10 +39,10 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
     val hash = new Hash(session, log)
     val repos = getRepos(reposPath, limit, format)
 
-    log.info("Hashing")
+    log.warn("Hashing")
     val result = hash.forRepos(repos)
 
-    log.info("Saving hashes to DB")
+    log.warn("Saving hashes to DB")
     hash.save(result, keyspace, tables)
   }
 

--- a/src/main/scala/tech/sourced/gemini/cmd/HashSparkApp.scala
+++ b/src/main/scala/tech/sourced/gemini/cmd/HashSparkApp.scala
@@ -79,7 +79,7 @@ object HashSparkApp extends App with Logging {
   parser.parse(args, HashAppConfig()) match {
     case Some(config) =>
       if (config.verbose) {
-        LogManager.getRootLogger.setLevel(Level.INFO)
+        LogManager.getRootLogger.setLevel(Level.WARN)
       }
       val sparkMaster = Properties.envOrElse("MASTER", "local[*]")
       println(s"Running Hashing as Apache Spark job, master: $sparkMaster")


### PR DESCRIPTION
This workaround takes care of last item from https://github.com/src-d/gemini/pull/125

It allows for `hash -v` and works around inability of muting INFO logs in Apache Spark itself AKA [SPARK-16784](https://issues.apache.org/jira/browse/SPARK-16784)

```
Using spark-submit from /Users/alex/src-d/appolo/spark-2.2.0-bin-hadoop2.7
Running Hashing as Apache Spark job, master: local[*]
Hashing 6 repositories in: 'src/test/resources/siva' ()
	file:/Users/alex/src-d/gemini/src/test/resources/siva/2636f3c62f1a407b2996da6e3fe6fdc5d1ccd764.siva
	file:/Users/alex/src-d/gemini/src/test/resources/siva/duplicate-files/9279be3cf07fb3cca4fc964b27acea57e0af461b.siva
	file:/Users/alex/src-d/gemini/src/test/resources/siva/duplicate-files/f281ab6f2e0e38dcc3af05360667d8f530c00103.siva
	file:/Users/alex/src-d/gemini/src/test/resources/siva/file.py
	file:/Users/alex/src-d/gemini/src/test/resources/siva/file_2.py
	file:/Users/alex/src-d/gemini/src/test/resources/siva/unique-files/5fb38a5744b2496ff8484e57b46a754433ede457.siva
 WARN 16:22:21 tech.sourced.gemini.Gemini (Gemini.scala:33) - Getting repositories at src/test/resources/siva in siva format
 WARN 16:22:25 tech.sourced.gemini.Gemini (Gemini.scala:42) - Hashing
 WARN 16:22:25 tech.sourced.gemini.Hash (Hash.scala:56) - Listing files
 WARN 16:22:27 tech.sourced.gemini.Hash (Hash.scala:67) - Extracting UASTs
 WARN 16:22:28 tech.sourced.gemini.Hash (Hash.scala:86) - Extracting features
 WARN 16:22:28 tech.sourced.gemini.Hash (Hash.scala:103) - creating document frequencies

[Stage 1:===================================================>   (188 + 4) / 200] 

 WARN 16:23:09 tech.sourced.gemini.Hash (Hash.scala:122) - hashing features
 WARN 16:23:09 tech.sourced.gemini.Gemini (Gemini.scala:45) - Saving hashes to DB
 WARN 16:23:09 tech.sourced.gemini.Hash (Hash.scala:148) - save meta to DB
 WARN 16:23:09 tech.sourced.gemini.Hash (Hash.scala:142) - save document frequencies to docfreq.json
 WARN 16:23:10 tech.sourced.gemini.Hash (Hash.scala:167) - save hashtables to DB
Done

./hash -v src/test/resources/siva  79.55s user 6.75s system 105% cpu 1:21.65 total
```