### PR TITLE
CI: Mute verbose logs

### DIFF
--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -7,4 +7,4 @@ sudo apt-get -qq update
 sudo apt-get --no-install-recommends -y install python3-pip libsnappy1 libsnappy-dev
 # pip==9.0.1 same version as sourced-ml uses
 sudo pip3 install --upgrade pip==9.0.1 setuptools wheel
-pip3 install -I --user --only-binary=numpy,scipy -r src/main/python/community-detector/requirements.txt pytest
+pip3 install -q -I --user --only-binary=numpy,scipy -r src/main/python/community-detector/requirements.txt pytest


### PR DESCRIPTION
Mute very verbose
```
[K    99% |â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 13.6MB 15.9MB/s eta 0:00:01
[K    99% |â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 13.6MB 12.1MB/s eta 0:00:01
[K    100% |â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 13.7MB 106kB/s 
[?25hCollecting python-igraph==0.7.1.post6 (from -r src/main/python/community-detector/requirements.txt (line 3))
Collecting scipy==1.0.1 (from -r src/main/python/community-detector/requirements.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/a0/27/68dff2a00ac77f27fa37dfefdd7b95a6b771621f736449ff455e9ae81b22/scipy-1.0.1-cp34-cp34m-manylinux1_x86_64.whl (47.7MB)
[?25l
[K    0% |                                | 10kB 30.9MB/s eta 0:00:02
[K    0% |                                | 20kB 28.8MB/s eta 0:00:02
```

i.e from https://api.travis-ci.org/v3/job/392664074/log.txt