### PR TITLE
Hash: apply performant defaults for PGA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,11 @@ services:
       - ./repositories:/repositories
       - ./query:/query
     environment:
-      DB_HOST: scylla
+      HOST: scylla
       BBLFSH_HOST: bblfshd
       FEATURES_EXTRACTOR_HOST: featurext
+    ports:
+      - "4040:4040"
 
   scylla:
     image: scylladb/scylla:2.0.0
@@ -23,6 +25,8 @@ services:
       - "127.0.0.1"
       - "--memory"
       - "2G"
+    ports:
+      - "9042:9042"
 
   featurext:
     build:

--- a/hash
+++ b/hash
@@ -46,6 +46,7 @@ sparkSubmit() {
 #  --conf "spark.local.dir=/spark-temp-data" \
 #  --conf "spark.executor.extraJavaOptions=-Djava.io.tmpdir=/spark-temp-data" \
 #  --conf "spark.eventLog.enabled=true" \
+#  --conf "spark.eventLog.dir=/repositories"
 
 # https://issues.apache.org/jira/browse/SPARK-16784
 # spark.executor.extraJavaOptions=-Dlog4j.configuration=log4j-spark.properties
@@ -55,6 +56,7 @@ sparkSubmit \
   --master "${MASTER:=local[*]}" \
   --name "${app_name}" \
   --jars "${deps_jar}" \
+  --conf "spark.driver.memory=4g" \
   --conf "spark.executor.memory=4g" \
   --conf "spark.default.parallelism=8" \
   --conf "spark.tech.sourced.engine.skip.read.errors=true" \

--- a/hash
+++ b/hash
@@ -59,6 +59,7 @@ sparkSubmit \
   --conf "spark.driver.memory=4g" \
   --conf "spark.executor.memory=4g" \
   --conf "spark.default.parallelism=8" \
+  --conf "spark.serializer=org.apache.spark.serializer.KryoSerializer" \
   --conf "spark.tech.sourced.engine.skip.read.errors=true" \
   --conf "spark.files.maxPartitionBytes=12582912" \
   --driver-java-options "-Dlog4j.configuration=jar:file:${jar}!/log4j.properties" \

--- a/hash
+++ b/hash
@@ -57,6 +57,8 @@ sparkSubmit \
   --jars "${deps_jar}" \
   --conf "spark.executor.memory=4g" \
   --conf "spark.default.parallelism=8" \
+  --conf "spark.tech.sourced.engine.skip.read.errors=true" \
+  --conf "spark.files.maxPartitionBytes=12582912" \
   --driver-java-options "-Dlog4j.configuration=jar:file:${jar}!/log4j.properties" \
   "${jar}" \
   "$@"

--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -5,6 +5,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.storage.StorageLevel
 import org.slf4j.{Logger => Slf4jLogger}
 import tech.sourced.engine._
 import tech.sourced.featurext.SparkFEClient
@@ -33,8 +34,8 @@ class Hash(session: SparkSession, log: Slf4jLogger) {
     * @param repos DataFrame with engine.getRepositories schema
     */
   def forRepos(repos: DataFrame): HashResult = {
-    val files = filesForRepos(repos).cache()
-    val uasts = extractUast(files).cache()
+    val files = filesForRepos(repos).persist(StorageLevel.MEMORY_AND_DISK_SER)
+    val uasts = extractUast(files).persist(StorageLevel.MEMORY_AND_DISK_SER)
     val features = extractFeatures(uasts).cache()
     val docFreq = makeDocFreq(uasts, features)
     val hashes = hashFeatures(docFreq, features)


### PR DESCRIPTION

 - smaller size of input data per thread
 - fix env var name in docker compose
 - add more memory for Spark in local mode (docker compose)
 - switch to efficient serialization library
 - change caching strategy (spill on disk serialized objects)