### PR TITLE
Use JSON parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   avro % Compile,
   parquetAvro % Compile,
   hadoopCommon % Compile,
-  scalaJsonParser % Compile //needed for docFreq reading, as scala.util.parsing.json was removed after Scala 2.10
+  scalaJsonParser % Compile //needed for docFreq reading
   //TODO(bzz): remove scalaJsonParser at https://github.com/src-d/gemini/issues/112
 )
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = false)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,6 +29,5 @@ object Dependencies {
   lazy val ioGrpc = "io.grpc" % "grpc-netty" % "1.10.0"
   lazy val commonsMath = "org.apache.commons" % "commons-math3" % "3.6.1"
   lazy val bblfshClient = "org.bblfsh" % "bblfsh-client" % "1.8.2"
-  lazy val scalaJsonParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.0"
-
+  lazy val scalaJsonParser = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
 }

--- a/src/main/scala/tech/sourced/gemini/FileQuery.scala
+++ b/src/main/scala/tech/sourced/gemini/FileQuery.scala
@@ -136,13 +136,12 @@ class FileQuery(conn: Session,
   }
 
   protected def hashFile(features: Iterable[Feature], docFreqFile: File): Array[Array[Long]] = {
-    log.info("Reading docFreq")
+    log.info(s"Reading docFreq from ${docFreqFile.getAbsolutePath}")
     val docFreq = OrderedDocFreq.fromJson(docFreqFile)
 
-    log.info("Started hashing file")
+    log.info("Started hashing a file")
     val hash = FeaturesHash.hashFeatures(docFreq, features)
-
-    log.info("Finished hashing file")
+    log.info("Finished hashing a file")
     hash
   }
 }

--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -10,7 +10,6 @@ import tech.sourced.engine._
 import tech.sourced.featurext.SparkFEClient
 import tech.sourced.featurext.generated.service.Feature
 
-import scala.collection.immutable
 
 
 case class RDDFeatureKey(token: String, doc: String)
@@ -104,18 +103,15 @@ class Hash(session: SparkSession, log: Slf4jLogger) {
   // TODO(max): Try to use DF here instead
   protected def makeDocFreq(uasts: DataFrame, features: RDD[RDDFeature]): OrderedDocFreq = {
     log.warn("creating document frequencies")
-
     val docs = uasts.select("document").distinct().count()
-
     val df = features
       .map(row => (row.key.token, row.key.doc))
       .distinct()
       .map(row => (row._1, 1))
       .reduceByKey((a, b) => a + b)
       .collectAsMap()
-    val tokens = df.keys.toList.sorted
-
-    OrderedDocFreq(docs.toInt, tokens, immutable.Map(df.toSeq:_*))
+    val tokens = df.keys.toArray.sorted
+    OrderedDocFreq(docs.toInt, tokens, df)
   }
 
   // TODO(max): Try to use DF here instead

--- a/src/main/scala/tech/sourced/gemini/OrderedDocFreq.scala
+++ b/src/main/scala/tech/sourced/gemini/OrderedDocFreq.scala
@@ -1,9 +1,12 @@
 package tech.sourced.gemini
 
 import java.io.{File, PrintWriter}
-import scala.collection.immutable
 
-import scala.util.parsing.json.{JSONArray, JSONObject}
+import scala.io.Source
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 
 /**
   * Ordered document frequency
@@ -12,37 +15,43 @@ import scala.util.parsing.json.{JSONArray, JSONObject}
   * @param tokens
   * @param df
   */
-case class OrderedDocFreq(docs: Int, tokens: immutable.List[String], df: immutable.Map[String, Int]) {
+case class OrderedDocFreq(docs: Int, tokens: IndexedSeq[String], df: collection.Map[String, Int]) {
   def saveToJson(filename: String): Unit = {
-    val jsonObj = JSONObject(immutable.Map[String, Any](
+    val mapper = new ObjectMapper() with ScalaObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+    val out = new PrintWriter(filename)
+    mapper.writeValue(out, Map(
       "docs" -> docs,
-      "tokens" -> JSONArray(tokens),
-      "df" -> JSONObject(df)
+      "tokens" -> tokens,
+      "df" -> df
     ))
-    val w = new PrintWriter(filename)
-    w.write(jsonObj.toString())
-    w.close()
+    out.close()
   }
 }
 
 object OrderedDocFreq {
   def fromJson(file: File): OrderedDocFreq = {
-    val docFreqMap = JSONUtils.parseFile[Map[String, Any]](file)
-
+    val docFreqMap = parseFile[Map[String, Any]](file)
     val docs = docFreqMap.get("docs") match {
-      case Some(v) => v.asInstanceOf[Double].toInt
-      case None => throw new Exception("can not parse docs in docFreq")
+      case Some(v) => v.asInstanceOf[Int]
+      case None => throw new RuntimeException(s"Can not parse key 'docs' in docFreq:${file.getAbsolutePath}")
     }
     val df = docFreqMap.get("df") match {
-      case Some(v) => v.asInstanceOf[Map[String, Double]].mapValues(_.toInt)
-      case None => throw new Exception("can not parse df in docFreq")
+      case Some(v) => v.asInstanceOf[Map[String, Int]]
+      case None => throw new RuntimeException(s"Can not parse key 'df' in docFreq:${file.getAbsolutePath}")
     }
     val tokens = docFreqMap.get("tokens") match {
-      case Some(v) => v.asInstanceOf[List[String]]
-      case None => throw new Exception("can not parse tokens in docFreq")
+      case Some(v) => v.asInstanceOf[List[String]].toArray
+      case None => throw new RuntimeException(s"Can not parse key 'tokens' in docFreq:${file.getAbsolutePath}")
     }
-
     OrderedDocFreq(docs, tokens, df)
+  }
+
+  def parseFile[T: Manifest](file: File): T = {
+    val json = Source.fromFile(file)
+    val mapper = new ObjectMapper with ScalaObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+    mapper.readValue[T](json.reader)
   }
 }
 

--- a/src/test/scala/tech/sourced/gemini/FileQuerySpec.scala
+++ b/src/test/scala/tech/sourced/gemini/FileQuerySpec.scala
@@ -55,7 +55,7 @@ class FileQuerySpec extends FlatSpec
 
   "Read from Database" should "return same results as written" in {
     val gemini = Gemini(null, logger, keyspace)
-    val bblfshClient = BblfshClient.apply(Gemini.defaultBblfshHost, Gemini.defaultBblfshPort)
+    val bblfshClient = BblfshClient(Gemini.defaultBblfshHost, Gemini.defaultBblfshPort)
     val channel = ManagedChannelBuilder
       .forAddress(Gemini.defaultFeHost, Gemini.defaultFePort)
       .usePlaintext(true)
@@ -68,6 +68,8 @@ class FileQuerySpec extends FlatSpec
     duplicates.head.sha should be("097f4a292c384e002c5b5ce8e15d746849af7b37") // git hash-object -w LICENSE
     duplicates.head.repo should be("null/Users/alex/src-d/gemini")
     duplicates.head.commit should be("4aa29ac236c55ebbfbef149fef7054d25832717f")
+    channel.shutdownNow()
+    //TODO(bzz): bblfshClient.shutdownNow() after https://github.com/bblfsh/client-scala/issues/71
   }
 
   /**
@@ -113,6 +115,7 @@ class FileQuerySpec extends FlatSpec
     queryResult = fileQuery.find(dupFile)
 
     server.shutdown()
+    channel.shutdownNow()
   }
 
   it should "return duplicates" in {


### PR DESCRIPTION
`scala.util.parsing.json` is deprecated and known to be not production ready parser implementation.

This PR replaces it with Jackson, that has performance benefit at Apache Spark case - it avoid copying 100s Mb object on the Driver.