### PR TITLE
Hash: src repo listing using Engine

### DIFF
--- a/src/test/scala/tech/sourced/gemini/SparkHashSpec.scala
+++ b/src/test/scala/tech/sourced/gemini/SparkHashSpec.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.slf4j.{Logger => Slf4jLogger}
+import tech.sourced.gemini.cmd.HashSparkApp
 
 @tags.Bblfsh
 @tags.FeatureExtractor
@@ -25,7 +26,6 @@ class SparkHashSpec extends FlatSpec
     "archiver.go",
     "archiver_test.go"
   )
-  var hashResult: HashResult = _
 
   // don't process content of repos to speedup tests
   class LimitedHash(s: SparkSession, log: Slf4jLogger) extends Hash(s, log) {
@@ -33,19 +33,18 @@ class SparkHashSpec extends FlatSpec
       super.filesForRepos(repos).filter(col("path").isin(filePaths: _*))
   }
   object LimitedHash {
-    def apply(s: SparkSession, log: Slf4jLogger) = new LimitedHash(s, log)
+    def apply(s: SparkSession, log: Slf4jLogger): LimitedHash = new LimitedHash(s, log)
   }
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-
+  def hashWithNewGemini(): HashResult = {
     val gemini = Gemini(sparkSession)
     val hash = LimitedHash(sparkSession, log)
     val repos = gemini.getRepos("src/test/resources/siva/duplicate-files")
-    hashResult = hash.forRepos(repos)
+    hash.forRepos(repos)
   }
 
   "Hash" should "return correct files" in {
+    val hashResult = hashWithNewGemini()
     val files = hashResult.files
     // num of files * num of repos
     files.count() shouldEqual 6
@@ -58,7 +57,7 @@ class SparkHashSpec extends FlatSpec
   }
 
   "Hash" should "calculate hashes" in {
-    val hashes = hashResult.hashes
+    val hashes = hashWithNewGemini().hashes
 
     // num of not-ignored files * num of repos
     hashes.count() shouldEqual 4
@@ -68,17 +67,34 @@ class SparkHashSpec extends FlatSpec
   }
 
   "Hash" should "generate docFreq" in {
-    val docFreq = hashResult.docFreq
+    val docFreq = hashWithNewGemini().docFreq
     // num of processed files * 2 repo
     docFreq.docs shouldEqual 4
     docFreq.tokens.size shouldEqual 738
-    docFreq.df(docFreq.tokens(0)) shouldEqual 3
+    docFreq.df(docFreq.tokens.head) shouldEqual 3
   }
 
   "Hash with limit" should "collect files only from limit repos" in {
     val gemini = Gemini(sparkSession)
     val repos = gemini.getRepos("src/test/resources/siva", 1).select("repository_path").distinct().count()
     repos should be(1)
+  }
+
+  ".siva files listing" should "include only files, reachable by Engine" in {
+    val path = "src/test/resources/siva"
+    val engine = tech.sourced.engine.Engine(sparkSession, path, "siva")
+    val repos = engine.getRepositories.select("repository_path").distinct
+    println(s"Expected: \n\t${repos.collect.mkString("\n\t")}")
+
+    val reposPaths = HashSparkApp.listRepositories(path, "siva", sparkSession)
+    println(s"Actual: \n\t${reposPaths.mkString("\n\t")}")
+
+    reposPaths.size shouldEqual repos.count
+  }
+
+  ".siva files listing" should "no include un-reachable .siva files" in {
+    val repos = HashSparkApp.listRepositories("src/test", "siva", sparkSession)
+    repos.length shouldBe 0
   }
 
 }


### PR DESCRIPTION
Fixes user experience \w Hash from #138

The only possible workaround \wo using Engine was
`org.apache.hadoop.fs.FileSystem#globStatus(org.apache.hadoop.fs.Path)`

but it did not work, as "$path/*" there does not match dirs recursively so

```scala
      fs.globStatus(new Path(s"$path/*"))
      .flatMap(file => if (file.getPath.getName.endsWith(".siva")) {
          Some(file.getPath)
        } else {
          None
        })
```

would not support bucketed repos, and thus would require us to mimic
`org.apache.hadoop.mapreduce.lib.input.FileInputFormat#listStatus`
manually which is way to involved.

