### PR TITLE
Hash: refactoring of feature hashing

### DIFF
--- a/src/main/scala/tech/sourced/gemini/FeaturesHash.scala
+++ b/src/main/scala/tech/sourced/gemini/FeaturesHash.scala
@@ -2,7 +2,6 @@ package tech.sourced.gemini
 
 import tech.sourced.featurext.generated.service.Feature
 
-import scala.collection.mutable
 import scala.collection.Searching._
 
 object FeaturesHash {
@@ -44,10 +43,10 @@ object FeaturesHash {
     * @param docFreq
     * @return
     */
-  private def toBagOfFeatures(features: Iterable[Feature], docFreq: OrderedDocFreq): Array[Double] = {
+  def toBagOfFeatures(features: Iterable[Feature], docFreq: OrderedDocFreq): Array[Double] = {
     val OrderedDocFreq(docs, tokens, df) = docFreq
 
-    val bag = new Array[Double](tokens.size)//mutable.ArrayBuffer.fill(tokens.size)(0.toDouble)
+    val bag = new Array[Double](tokens.size) //mutable.ArrayBuffer.fill(tokens.size)(0.toDouble)
     features.foreach { feature =>
       tokens.search(feature.name) match {
         case Found(idx) => {

--- a/src/main/scala/tech/sourced/gemini/FeaturesHash.scala
+++ b/src/main/scala/tech/sourced/gemini/FeaturesHash.scala
@@ -13,22 +13,20 @@ object FeaturesHash {
   val defaultHashtablesNum = 20
   val defaultBandSize = 8
 
-  private var tokensSize: Int = _
-  private var wmh: WeightedMinHash = _
-
-  def hashFeatures(
-                    docFreq: OrderedDocFreq,
-                    features: Iterable[Feature],
-                    sampleSize: Int = defaultSampleSize,
-                    seed: Int = defaultSeed): Array[Array[Long]] = synchronized {
-    // keep created WeightedMinHash instance cause the calculation of parameters is expensive for large dimension
-    if (wmh == null || tokensSize != docFreq.tokens.size) {
-      wmh = new WeightedMinHash(docFreq.tokens.size, sampleSize, seed)
-      tokensSize = docFreq.tokens.size
-    }
-
-    val bag = toBagOfFeatures(features, docFreq)
-    wmh.hash(bag)
+  /**
+    * Factory method for initializing WMH data structure
+    * \w default parameters, specific to Gemini.
+    *
+    * Allocates at lest 2*dim*sampleSize memory
+    *
+    * @param dim weight vector size
+    * @param sampleSize number of samples
+    * @param seed
+    * @return
+    */
+  def initWmh(dim: Int, sampleSize: Int = defaultSampleSize, seed: Int = defaultSeed): WeightedMinHash = {
+    val wmh = new WeightedMinHash(dim, sampleSize, seed)
+    wmh
   }
 
   /**

--- a/src/main/scala/tech/sourced/gemini/FeaturesHash.scala
+++ b/src/main/scala/tech/sourced/gemini/FeaturesHash.scala
@@ -17,7 +17,7 @@ object FeaturesHash {
     * Factory method for initializing WMH data structure
     * \w default parameters, specific to Gemini.
     *
-    * Allocates at lest 2*dim*sampleSize memory
+    * Allocates at least 2*dim*sampleSize*8 bytes of RAM
     *
     * @param dim weight vector size
     * @param sampleSize number of samples
@@ -44,7 +44,7 @@ object FeaturesHash {
   def toBagOfFeatures(features: Iterable[Feature], docFreq: OrderedDocFreq): Array[Double] = {
     val OrderedDocFreq(docs, tokens, df) = docFreq
 
-    val bag = new Array[Double](tokens.size) //mutable.ArrayBuffer.fill(tokens.size)(0.toDouble)
+    val bag = new Array[Double](tokens.size)
     features.foreach { feature =>
       tokens.search(feature.name) match {
         case Found(idx) => {

--- a/src/main/scala/tech/sourced/gemini/FileQuery.scala
+++ b/src/main/scala/tech/sourced/gemini/FileQuery.scala
@@ -139,7 +139,7 @@ class FileQuery(conn: Session,
     log.info(s"Reading docFreq from ${docFreqFile.getAbsolutePath}")
     val docFreq = OrderedDocFreq.fromJson(docFreqFile)
 
-    log.info(s"Initialize WMH for ")
+    log.info(s"Initialize WMH")
     val wmh = FeaturesHash.initWmh(docFreq.tokens.size)
 
     log.info("Started hashing a file")

--- a/src/main/scala/tech/sourced/gemini/FileQuery.scala
+++ b/src/main/scala/tech/sourced/gemini/FileQuery.scala
@@ -139,8 +139,12 @@ class FileQuery(conn: Session,
     log.info(s"Reading docFreq from ${docFreqFile.getAbsolutePath}")
     val docFreq = OrderedDocFreq.fromJson(docFreqFile)
 
+    log.info(s"Initialize WMH for ")
+    val wmh = FeaturesHash.initWmh(docFreq.tokens.size)
+
     log.info("Started hashing a file")
-    val hash = FeaturesHash.hashFeatures(docFreq, features)
+    val bag = FeaturesHash.toBagOfFeatures(features, docFreq)
+    val hash = wmh.hash(bag)
     log.info("Finished hashing a file")
     hash
   }

--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -1,6 +1,7 @@
 package tech.sourced.gemini
 
 import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra._
 import org.apache.spark.sql.functions._
@@ -39,7 +40,7 @@ class Hash(session: SparkSession, log: Slf4jLogger) {
     val docFreq = makeDocFreq(uasts, features)
     val hashes = hashFeatures(docFreq, features)
 
-    HashResult(files, hashes, docFreq)
+    HashResult(files, hashes, docFreq.value)
   }
 
   /**
@@ -102,7 +103,7 @@ class Hash(session: SparkSession, log: Slf4jLogger) {
   }
 
   // TODO(max): Try to use DF here instead
-  protected def makeDocFreq(uasts: DataFrame, features: RDD[RDDFeature]): OrderedDocFreq = {
+  protected def makeDocFreq(uasts: DataFrame, features: RDD[RDDFeature]): Broadcast[OrderedDocFreq] = {
     log.warn("creating document frequencies")
     val docs = uasts.select("document").distinct().count()
     val df = features
@@ -112,12 +113,12 @@ class Hash(session: SparkSession, log: Slf4jLogger) {
       .reduceByKey((a, b) => a + b)
       .collectAsMap()
     val tokens = df.keys.toArray.sorted
-    OrderedDocFreq(docs.toInt, tokens, df)
+    session.sparkContext.broadcast(OrderedDocFreq(docs.toInt, tokens, df))
   }
 
   // TODO(max): Try to use DF here instead
   protected def hashFeatures(
-                              docFreq: OrderedDocFreq,
+                              docFreq: Broadcast[OrderedDocFreq],
                               featuresRdd: RDD[RDDFeature]): RDD[RDDHash] = {
     log.warn("hashing features")
     val tf = featuresRdd
@@ -128,9 +129,9 @@ class Hash(session: SparkSession, log: Slf4jLogger) {
       .map(row => (row._1.doc, Feature(row._1.token, row._2)))
       .groupByKey(session.sparkContext.defaultParallelism)
       .mapPartitions { partIter =>
-        val wmh = FeaturesHash.initWmh(docFreq.tokens.size) // ~1.6 Gb (for 1 PGA bucket)
+        val wmh = FeaturesHash.initWmh(docFreq.value.tokens.size) // ~1.6 Gb (for 1 PGA bucket)
         partIter.map { case (doc, features) =>
-          RDDHash(doc, wmh.hash(FeaturesHash.toBagOfFeatures(features, docFreq)))
+          RDDHash(doc, wmh.hash(FeaturesHash.toBagOfFeatures(features, docFreq.value)))
         }
     }
     tfIdf

--- a/src/test/scala/tech/sourced/gemini/SparkHashSpec.scala
+++ b/src/test/scala/tech/sourced/gemini/SparkHashSpec.scala
@@ -62,8 +62,8 @@ class SparkHashSpec extends FlatSpec
     // num of not-ignored files * num of repos
     hashes.count() shouldEqual 4
     // make sure rdd contains correct values
-    val row = hashes.collect().last
-    row.doc shouldEqual "github.com/src-d/borges.git//archiver_test.go@7558786958f6084188135b773f4457472a9e4052"
+    val rows = hashes.collect.map(_.doc)
+    rows should contain ("github.com/src-d/borges.git//archiver_test.go@7558786958f6084188135b773f4457472a9e4052")
   }
 
   "Hash" should "generate docFreq" in {


### PR DESCRIPTION
Based on #142  (only last 3 commits are new)

 - [x] This changes client API to make explicit dependency on expensive WMH data-structure,
instead of a keeping it in a global static state.

   This allows for more fine-grain control over resources and speeds up hashing ~2.5 times by removing excessive synchronization between task threads in executors processes on Spark.

 - [x] Broadcast DocFreq to avoid sending it \w every task (~100Mb for 1 PGA bucket)