### PR TITLE
Fix exception of counter report when its empty

### DIFF
--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -32,9 +32,10 @@ class Hash(session: SparkSession, log: Slf4jLogger) {
 
   def report(header: String, countProcessed: Long, skipped: MapAccumulator): Unit = {
     log.warn(header)
-    val countSkipepd = skipped.value.map(_._2).reduceLeft(_ + _)
-    log.warn(s"Processed: $countProcessed, skipped: $countSkipepd")
-    skipped.value.toSeq.sortBy(-_._2) foreach { case (key, value) => log.warn(s"\t$key -> $value") }
+    val skippedSeq = skipped.value.toSeq
+    val countSkipped = skippedSeq.map(_._2).sum
+    log.warn(s"Processed: $countProcessed, skipped: $countSkipped")
+    skippedSeq.sortBy(-_._2) foreach { case (key, value) => log.warn(s"\t$key -> $value") }
   }
 
   /**


### PR DESCRIPTION
I run `hash` on `src/test/resources/siva/duplicate-files/` and got exception:

```
Exception in thread "main" java.lang.UnsupportedOperationException: empty.reduceLeft
	at scala.collection.LinearSeqOptimized$class.reduceLeft(LinearSeqOptimized.scala:137)
	at scala.collection.immutable.List.reduceLeft(List.scala:84)
	at tech.sourced.gemini.Hash.report(Hash.scala:35)
	at tech.sourced.gemini.Hash.forRepos(Hash.scala:51)
	at tech.sourced.gemini.Gemini.hash(Gemini.scala:44)
	at tech.sourced.gemini.cmd.HashSparkApp$.delayedEndpoint$tech$sourced$gemini$cmd$HashSparkApp$1(HashSparkApp.scala:119)
	at tech.sourced.gemini.cmd.HashSparkApp$delayedInit$body.apply(HashSparkApp.scala:33)
	at scala.Function0$class.apply$mcV$sp(Function0.scala:34)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
	at scala.App$$anonfun$main$1.apply(App.scala:76)
	at scala.App$$anonfun$main$1.apply(App.scala:76)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:35)
	at scala.App$class.main(App.scala:76)
	at tech.sourced.gemini.cmd.HashSparkApp$.main(HashSparkApp.scala:33)
	at tech.sourced.gemini.cmd.HashSparkApp.main(HashSparkApp.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:775)
	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:180)
	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:205)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:119)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```