### PR TITLE
Set python base image version to 3.6

### DIFF
--- a/FE.Dockerfile
+++ b/FE.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Some dependencies don't compile on 3.7.
