### PR TITLE
bump engine to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You would need:
  - Apache Cassandra or ScyllaDB
  - Apache Spark
  - Python 3
+ - [Bblfshd](https://github.com/bblfsh/bblfshd/) v2.5.0+
  - Go (optional)
 
 By default, all commands are going to use

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       PYTHONHASHSEED: "0"
 
   bblfshd:
-    image: bblfsh/bblfshd:v2.4.2
+    image: bblfsh/bblfshd:v2.5.0
     privileged: true
     volumes:
       - /var/lib/bblfshd

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   lazy val spark = "org.apache.spark" %% "spark-core" % "2.2.0"
   lazy val fixNetty = "io.netty" % "netty-all" % "4.1.17.Final"
   lazy val fixNewerHadoopClient = "org.apache.hadoop" % "hadoop-client" % "2.7.2"
-  lazy val engine = "tech.sourced" % "engine" % "0.6.3" classifier "slim"
+  lazy val engine = "tech.sourced" % "engine" % "0.7.0" classifier "slim"
   lazy val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"
   lazy val cassandraSparkConnector = "com.datastax.spark" %% "spark-cassandra-connector" % "2.0.6"
   lazy val cassandraDriverMetrics = "com.codahale.metrics" % "metrics-core" % "3.0.2"

--- a/src/test/scala/tech/sourced/gemini/FileQuerySpec.scala
+++ b/src/test/scala/tech/sourced/gemini/FileQuerySpec.scala
@@ -165,6 +165,10 @@ class FileQuerySpec extends FlatSpec
       override def version(request: VersionRequest): Future[VersionResponse] = {
         Future.successful(VersionResponse())
       }
+
+      override def supportedLanguages(request: SupportedLanguagesRequest): Future[SupportedLanguagesResponse] = {
+        Future.successful(SupportedLanguagesResponse())
+      }
     }
 
     new BblfshServerMock


### PR DESCRIPTION
Related things for us:
- support for Apache Spark 2.3 https://github.com/src-d/engine/pull/403
- bblfsh: do not send requests for unsupported languages https://github.com/src-d/engine/pull/404

Looks like the last one allows to remove list of languages from gemini completely https://github.com/src-d/gemini/issues/129