### PR TITLE
Pass func name and line to query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,9 @@ matrix:
         # query with similarity (funcs)
         - ./query -m func ./src/test/resources/func_mod.go | tee query_result.txt
         - grep "Similar funcs of ./src/test/resources/func_mod.go" query_result.txt > /dev/null
+        # query with filter (funcs)
+        - ./query -m func "./src/test/resources/func_mod.go:B:12" | tee query_result.txt
+        - grep "Similar funcs of ./src/test/resources/func_mod.go:B:12" query_result.txt > /dev/null
         # report with similarity
         - ./report | tee report_result.txt
         # check both identical & similar files/functions appeared in output

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -89,11 +89,12 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
             mode: String,
             docFreqPath: String = "",
             feClient: FeatureExtractor): QueryResult = {
+    log.info(s"Query for items similar to $inPath")
     val (path, fnFilter) = fileWithFuncPattern.findFirstMatchIn(inPath) match {
       case Some(m) => (new File(m.group(1)), Some(m.group(2), m.group(3).toInt))
       case None => (new File(inPath), None)
     }
-    log.info(s"Query for items similar to $path")
+
     if (path.isDirectory) {
       QueryResult(findDuplicateProjects(path, conn, keyspace), findSimilarProjects(path))
     } else {

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -79,7 +79,7 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
   /**
     * Search for duplicates and similar items to the given one.
     *
-    * @param inPath path to an item
+    * @param inPath path to an item in format path/to/file:func:line (func:line) are optional
     * @param conn   Database connection
     * @return
     */


### PR DESCRIPTION
Fix #162

The last item in the list. Adds support for querying only 1 function in a file:
```
/query ./filename.ext:funcName:lineNumber
```
