### PR TITLE
Use bblfsh-drivers image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,8 +124,6 @@ before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
-  # make bblfsh images readable
-  - sudo chmod -R 777 $HOME/bblfsh-drivers/images
 
 cache:
   directories:
@@ -133,5 +131,4 @@ cache:
     - $HOME/.sbt
     - $HOME/.ivy2/cache
     - $HOME/.coursier
-    - $HOME/bblfsh-drivers/images
     - $HOME/.cache/pip/wheels

--- a/docker-compose.host.yml
+++ b/docker-compose.host.yml
@@ -1,18 +1,16 @@
-version: "3"
+version: '3'
 services:
   gemini:
-    network_mode: "host"
+    network_mode: 'host'
 
   scylla:
     ports:
-      - "9042:9042"
+      - '9042:9042'
 
   featurext:
     ports:
-      - "9001:9001"
+      - '9001:9001'
 
   bblfshd:
     ports:
-      - "9432:9432"
-    volumes:
-      - $HOME/bblfsh-drivers:/var/lib/bblfshd
+      - '9432:9432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 services:
   gemini:
     build: .
@@ -10,35 +10,31 @@ services:
       BBLFSH_HOST: bblfshd
       FEATURES_EXTRACTOR_HOST: featurext
     ports:
-      - "4040:4040"
+      - '4040:4040'
 
   scylla:
     image: scylladb/scylla:2.0.0
     volumes:
       - /var/lib/scylla
     command:
-      - "--broadcast-address"
-      - "127.0.0.1"
-      - "--listen-address"
-      - "0.0.0.0"
-      - "--broadcast-rpc-address"
-      - "127.0.0.1"
-      - "--memory"
-      - "2G"
+      - '--broadcast-address'
+      - '127.0.0.1'
+      - '--listen-address'
+      - '0.0.0.0'
+      - '--broadcast-rpc-address'
+      - '127.0.0.1'
+      - '--memory'
+      - '2G'
     ports:
-      - "9042:9042"
+      - '9042:9042'
 
   featurext:
     build:
       context: .
       dockerfile: FE.Dockerfile
     environment:
-      PYTHONHASHSEED: "0"
+      PYTHONHASHSEED: '0'
 
   bblfshd:
-    image: bblfsh/bblfshd:v2.5.0
+    image: bblfsh/bblfshd:v2.11.0-drivers
     privileged: true
-    volumes:
-      - /var/lib/bblfshd
-    entrypoint: ["/bin/sh"]
-    command: ["-c", "bblfshd & sleep 5 && bblfshctl driver install --recommended && tail -f /dev/null"]


### PR DESCRIPTION
Downloading drivers fails because of github api limit. It's better to
use image with drivers.

Ref: https://github.com/src-d/gemini/issues/179

Signed-off-by: Maxim Sukharev <max@smacker.ru>