### PR TITLE
add support for Google Cloud Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Hash command specific arguments:
 
  * `-l/--limit` - limit the number of repositories to be processed. All repositories will be processed by default
  * `-f/--format` - format of the stored repositories. Supported input data formats that repositories could be stored in are `siva`, `bare` or `standard`, default `siva`
+ * `--gcs-keyfile` - path to [JSON keyfile](https://cloud.google.com/storage/docs/authentication) for authentication in Google Cloud Storage
 
 ## Development
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= Seq(
   scalapbGrpc % Compile,
   engine % Compile,
   jgit % Compile,
+  gcs % Compile,
   fixNetty,
   cassandraDriverMetrics % Provided, //needed for using Driver \wo Spark from SparkConnector
   cassandraSparkConnector % Compile,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,10 +24,11 @@ object Dependencies {
   lazy val hadoopCommon = ("org.apache.hadoop" % "hadoop-common" % "2.6.5")
     .exclude("com.sun.jersey", "jersey-server")
     .exclude("commons-beanutils", "commons-beanutils-core")
-  lazy val scalapb = "com.thesamet.scalapb" %% "scalapb-runtime" % "0.7.1"
-  lazy val scalapbGrpc = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % "0.7.1"
+  lazy val scalapb = "com.thesamet.scalapb" %% "scalapb-runtime" % "0.8.4"
+  lazy val scalapbGrpc = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % "0.8.4"
   lazy val ioGrpc = "io.grpc" % "grpc-netty" % "1.10.0"
   lazy val commonsMath = "org.apache.commons" % "commons-math3" % "3.6.1"
   lazy val bblfshClient = "org.bblfsh" % "bblfsh-client" % "1.8.2"
   lazy val scalaJsonParser = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
+  lazy val gcs = "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop2-1.9.11"
 }


### PR DESCRIPTION
- Allows to use gcs path for files as: gcs://bucket/path
- Adds new flag --gcs-keyfile to hash command for authorization

I added gcs-connector to the deps jar instead of sending it separatly to
spark due to conflicts in guava between spark 2.2 and gcs-connector.

I also updated scalapb to avoid multiple shading of guava for
gcs-connector and grpc separatly. Now both use compatible versions.

Signed-off-by: Maxim Sukharev <max@smacker.ru>