### PR TITLE
require empty db keyspace to run hash

### DIFF
--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -130,7 +130,7 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
   }
 
   def isDBEmpty(session: Session, mode: String): Boolean = {
-    var row = session.execute(s"select count(*) from $keyspace.${tables.docFreq} where id='$mode'").one()
+    var row = session.execute(s"select count(*) from $keyspace.${tables.docFreq} where id='$mode' limit 1").one()
     if (row.getLong(0) > 0) {
       return false
     }

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -129,6 +129,25 @@ class Gemini(session: SparkSession, log: Slf4jLogger, keyspace: String = Gemini.
     ReportResult(duplicates, similarities)
   }
 
+  def isDBEmpty(session: Session, mode: String): Boolean = {
+    var row = session.execute(s"select count(*) from $keyspace.${tables.docFreq} where id='$mode'").one()
+    if (row.getLong(0) > 0) {
+      return false
+    }
+
+    row = session.execute(s"select count(*) from $keyspace.${tables.hashtables}_$mode").one()
+    if (row.getLong(0) > 0) {
+      return false
+    }
+
+    true
+  }
+
+  def cleanDB(session: Session, mode: String): Unit = {
+    session.execute(s"delete from $keyspace.${tables.docFreq} where id='$mode'")
+    session.execute(s"truncate table $keyspace.${tables.hashtables}_$mode")
+  }
+
   def applySchema(session: Session): Unit = {
     log.debug("CQL: creating schema")
     Source

--- a/src/main/scala/tech/sourced/gemini/cmd/HashSparkApp.scala
+++ b/src/main/scala/tech/sourced/gemini/cmd/HashSparkApp.scala
@@ -143,9 +143,7 @@ object HashSparkApp extends App with Logging {
 
         if (config.replace) {
           gemini.cleanDB(cassandra, config.mode)
-        }
-
-        if (!gemini.isDBEmpty(cassandra, config.mode)) {
+        } else if (!gemini.isDBEmpty(cassandra, config.mode)) {
           println("Database keyspace is not empty! Hashing may produce wrong results. " +
             "Please choose another keyspace or pass the --replace option")
           System.exit(2)

--- a/src/main/scala/tech/sourced/gemini/cmd/ReportApp.scala
+++ b/src/main/scala/tech/sourced/gemini/cmd/ReportApp.scala
@@ -58,8 +58,8 @@ object ReportApp extends App {
         })
       .action((x, c) => c.copy(output = x))
       .text("output format")
-    opt[Boolean]("cassandra")
-      .action((x, c) => c.copy(cassandra = x))
+    opt[Unit]("cassandra")
+      .action((x, c) => c.copy(cassandra = true))
       .text("Enable advanced cql queries for Apache Cassandra database")
   }
 


### PR DESCRIPTION
Hashing can't be executed incrementally due to calculation of document
frequencies which require full input.

this commit checks if hashtables and docfreq tables are empty and gemini
exits with error if they are not.

it also introduces new flag --replace which would clean up db for
current hashing mode.

There is also separate commit that changes type of cassandra flag to unit.
It allows to pass just `--cassandra` instead of `--cassandra=true`
(for consistency)

Output when db isn't empty:
```
$ ./hash src/test/resources/siva/duplicate-files/
Using spark-submit from ./spark
Running Hashing as Apache Spark job, master: local[*]
Hashing 2 repositories in: 'src/test/resources/siva/duplicate-files/' ()
	file:/Users/smacker/Work/gemini/src/test/resources/siva/duplicate-files/f281ab6f2e0e38dcc3af05360667d8f530c00103.siva
	file:/Users/smacker/Work/gemini/src/test/resources/siva/duplicate-files/9279be3cf07fb3cca4fc964b27acea57e0af461b.siva
Database keyspace is not empty! Hashing may produce wrong results. Please choose another keyspace or pass --replace argument
smacker in ~/Work/gemini on master [!?$]
```