### PR TITLE
move feature frequencies to separate table

### DIFF
--- a/src/main/resources/schema.cql
+++ b/src/main/resources/schema.cql
@@ -3,4 +3,5 @@ USE __KEYSPACE__;
 CREATE TABLE IF NOT EXISTS __KEYSPACE__.meta (sha1 ascii, repo text, commit ascii, path text, PRIMARY KEY (sha1, repo, commit, path));
 CREATE TABLE IF NOT EXISTS __KEYSPACE__.hashtables_file (sha1 text, hashtable tinyint, value blob, PRIMARY KEY (hashtable, value, sha1));
 CREATE TABLE IF NOT EXISTS __KEYSPACE__.hashtables_func (sha1 text, hashtable tinyint, value blob, PRIMARY KEY (hashtable, value, sha1));
-CREATE TABLE IF NOT EXISTS __KEYSPACE__.docfreq (id text, docs int, df map<text, int>, PRIMARY KEY (id));
+CREATE TABLE IF NOT EXISTS __KEYSPACE__.features_docs (id text, docs int, PRIMARY KEY (id));
+CREATE TABLE IF NOT EXISTS __KEYSPACE__.features_freq (id text, feature text, weight int, PRIMARY KEY (id, feature));

--- a/src/main/scala/tech/sourced/gemini/Database.scala
+++ b/src/main/scala/tech/sourced/gemini/Database.scala
@@ -7,22 +7,31 @@ import scala.collection.JavaConverters._
 
 case class MetaCols(sha: String, repo: String, commit: String, path: String)
 case class HashtablesCols(sha: String, hashtable: String, value: String)
-case class DocFreqCols(id: String, docs: String, df: String)
+case class FeaturesDocsCols(id: String, docs: String)
+case class FeaturesFreqCols(id: String, feature: String, weight: String)
 
 /**
   * Tables is static typed definition of DB schema
   *
   * @param meta name of meta table
-  * @param hashtables name of hashtables table
-  * @param metaCols
-  * @param hashtablesCols
+  * @param hashtables prefix of hashtables table
+  * @param featuresDocs name of features documents table
+  * @param featuresFreq name of features frequencies table
+  * @param metaCols columns of meta table
+  * @param hashtablesCols columns of hashtables table
+  * @param featuresDocsCols columns of features documents table
+  * @param featuresFreqCols columns of features frequencies table
   */
 case class Tables(meta: String,
                   hashtables: String,
-                  docFreq: String,
+                  featuresDocs: String,
+                  featuresFreq: String,
                   metaCols: MetaCols,
                   hashtablesCols: HashtablesCols,
-                  docFreqCols: DocFreqCols)
+                  featuresDocsCols: FeaturesDocsCols,
+                  featuresFreqCols: FeaturesFreqCols) {
+  def hashtables(mode: String): String = s"${hashtables}_$mode"
+}
 
 /**
   * Database object contains common queries to DB

--- a/src/main/scala/tech/sourced/gemini/FileQuery.scala
+++ b/src/main/scala/tech/sourced/gemini/FileQuery.scala
@@ -194,7 +194,7 @@ class FileQuery(
     } else {
       var tokens = IndexedSeq[String]()
       val df = conn
-        .execute(s"SELECT * FROM ${tables.featuresFreq} WHERE ${freqCols.id} = '$mode'")
+        .execute(s"SELECT * FROM ${tables.featuresFreq} WHERE ${freqCols.id} = '$mode' ORDER BY ${freqCols.feature}")
         .asScala
         .map { row =>
           // tokens have to be sorted, df.keys isn't sorted

--- a/src/main/scala/tech/sourced/gemini/Gemini.scala
+++ b/src/main/scala/tech/sourced/gemini/Gemini.scala
@@ -198,10 +198,12 @@ object Gemini {
   val tables = Tables(
     "meta",
     "hashtables",
-    "docfreq",
+    "features_docs",
+    "features_freq",
     MetaCols("sha1", "repo", "commit", "path"),
     HashtablesCols("sha1", "hashtable", "value"),
-    DocFreqCols("id", "docs", "df")
+    FeaturesDocsCols("id", "docs"),
+    FeaturesFreqCols("id", "feature", "weight")
   )
 
   val formatter = new ObjectInserter.Formatter

--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -238,12 +238,11 @@ class Hash(session: SparkSession,
       )
 
       val freqCols = tables.featuresFreqCols
+      val prepared = cassandra.prepare(s"INSERT INTO $keyspace.${tables.featuresFreq}" +
+        s"(${freqCols.id}, ${freqCols.feature}, ${freqCols.weight}) VALUES (?, ?, ?)")
+
       docFreq.df.foreach { case(feature, weight) =>
-        cassandra.execute(
-          s"INSERT INTO $keyspace.${tables.featuresFreq}" +
-            s"(${freqCols.id}, ${freqCols.feature}, ${freqCols.weight}) VALUES (?, ?, ?)",
-            mode, feature, int2Integer(weight)
-        )
+        cassandra.execute(prepared.bind(mode, feature, int2Integer(weight)))
       }
     }
   }

--- a/src/main/scala/tech/sourced/gemini/Report.scala
+++ b/src/main/scala/tech/sourced/gemini/Report.scala
@@ -63,8 +63,7 @@ class Report(conn: Session, log: Slf4jLogger, keyspace: String, tables: Tables) 
     */
   def findConnectedComponents(mode: String): (Map[Int, Set[Int]], Map[Int, List[Int]], Map[String, Int]) = {
     log.info(s"Finding ${mode} connected components")
-    val hashtablesTable = s"${tables.hashtables}_${mode}"
-    val cc = new DBConnectedComponents(log, conn, hashtablesTable, keyspace)
+    val cc = new DBConnectedComponents(log, conn, tables.hashtables(mode), keyspace)
     val (buckets, elementIds) = cc.makeBuckets()
     val elsToBuckets = cc.elementsToBuckets(buckets)
 


### PR DESCRIPTION
Map field of cassanda/scylladb works great but on many repositories
dictionary becomes too big and scylladb can't commit the row with
default configuration:

exception during mutation write to xx.xx.xx.xx: std::invalid_argument
(Mutation of 45358979 bytes is too large for the maxiumum size of 16777216)

it's possible to increase commit size but for really huge dataset the
dictionary would exceed any reasonable limit.

Signed-off-by: Maxim Sukharev <max@smacker.ru>