### PR TITLE
filter files with null language

### DIFF
--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -135,6 +135,7 @@ class Hash(session: SparkSession,
     files
       .dropDuplicates("blob_id")
       .classifyLanguages
+      .filter('lang.isNotNull)
       .extractUASTs
       .select("repository_id", "path", "blob_id", "uast")
       .filter(_.getAs[Seq[Array[Byte]]]("uast").nonEmpty)


### PR DESCRIPTION
extractUASTs UDF sends files to bblfsh when language is null to guess
the language on bblfsh side which doesn't make sense and slows down
hashing.

Signed-off-by: Maxim Sukharev <max@smacker.ru>