### PR TITLE
Filters by file size

### DIFF
--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -43,6 +43,9 @@ class Hash(session: SparkSession,
            mode: String = Gemini.fileSimilarityMode,
            docFreqPath: String = "") {
 
+  // very small files produce too much false positives
+  val fileSizeThresholdBytes = 500
+
   import session.implicits._
 
   def report(header: String, countProcessed: Long, skipped: MapAccumulator): Unit = {
@@ -139,6 +142,7 @@ class Hash(session: SparkSession,
 
     files
       .dropDuplicates("blob_id")
+      .filter('content_size > fileSizeThresholdBytes)
       .classifyLanguages
       .filter('lang.isNotNull)
       .extractUASTs

--- a/src/main/scala/tech/sourced/gemini/Hash.scala
+++ b/src/main/scala/tech/sourced/gemini/Hash.scala
@@ -140,9 +140,15 @@ class Hash(session: SparkSession,
   protected def extractUast(files: DataFrame): DataFrame = {
     log.warn("Extracting UASTs")
 
-    files
-      .dropDuplicates("blob_id")
-      .filter('content_size > fileSizeThresholdBytes)
+    val blobs = files.dropDuplicates("blob_id")
+
+    val filteredBlobs = if (mode == Gemini.fileSimilarityMode) {
+      blobs.filter('content_size > fileSizeThresholdBytes)
+    } else {
+      blobs
+    }
+
+    filteredBlobs
       .classifyLanguages
       .filter('lang.isNotNull)
       .extractUASTs

--- a/src/test/scala/tech/sourced/gemini/ReportSpec.scala
+++ b/src/test/scala/tech/sourced/gemini/ReportSpec.scala
@@ -104,12 +104,12 @@ class ReportSpec extends FlatSpec
     val similarGroups = report.findSimilarItems("/tmp/report-files-test", Gemini.fileSimilarityMode)
     println("Done")
 
-    similarGroups should have size 6
+    similarGroups should have size 7
 
     val files = similarGroups.head.map(_.toString)
     files.toSeq should contain theSameElementsAs Seq(
-      "https://github.com/erizocosmico/borges/blob/b1fcd3bf0ba810c05cb418babc09cc7f7783cc03/fixtures_test.go",
-      "https://github.com/src-d/borges/blob/e784f9d5f59d5c081c5f8f71b6c517918b899df0/fixtures_test.go"
+      "https://github.com/erizocosmico/borges/blob/b1fcd3bf0ba810c05cb418babc09cc7f7783cc03/consumer_test.go",
+      "https://github.com/src-d/borges/blob/e784f9d5f59d5c081c5f8f71b6c517918b899df0/consumer_test.go"
     )
   }
 


### PR DESCRIPTION
1.  Remove empty files from hashing

On real test dataset it produces 1500 duplicates and is not valuable for
a user.

2.  Exclude very small files from similarity hashing

On real dataset too small files produce too much false positives.
Also very small files as duplicates aren't very valuable, it doesn't
make sense to abstract common code for them.