### PR TITLE
update enry to v1.7.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ libraryDependencies ++= Seq(
   fixNewerHadoopClient % Provided, //due to newer v. of guava
 
   scalaLib % Compile,
+  bblfshClient % Compile,
   scalapb % Compile,
   ioGrpc % Compile,
   scalapbGrpc % Compile,
@@ -32,9 +33,9 @@ libraryDependencies ++= Seq(
   log4j12 % Compile,
   log4jBinding % Compile,
   commonsMath % Compile,
-  bblfshClient % Compile,
   avro % Compile,
   parquetAvro % Compile,
+  enry % Compile,
   scalaJsonParser % Compile //needed for docFreq reading
   //TODO(bzz): remove scalaJsonParser at https://github.com/src-d/gemini/issues/112
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,4 +33,5 @@ object Dependencies {
   lazy val bblfshClient = "org.bblfsh" % "bblfsh-client" % "1.8.2"
   lazy val scalaJsonParser = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
   lazy val gcs = "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop2-1.9.11"
+  lazy val enry = "tech.sourced" % "enry-java" % "1.7.1"
 }


### PR DESCRIPTION
it fixes segfault on macOs Mojave

Signed-off-by: Maxim Sukharev <max@smacker.ru>