### PR TITLE
A small fixup around bblfsh client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gemini [![Build Status](https://travis-ci.org/src-d/gemini.svg?branch=master)](https://travis-ci.org/src-d/gemini) [![codecov](https://codecov.io/gh/src-d/gemini/branch/master/graph/badge.svg)](https://codecov.io/gh/src-d/gemini)
+# Gemini [![Build Status](https://travis-ci.com/src-d/gemini.svg?branch=master)](https://travis-ci.com/src-d/gemini) [![codecov](https://codecov.io/gh/src-d/gemini/branch/master/graph/badge.svg)](https://codecov.io/gh/src-d/gemini)
 > Find similar code in Git repositories
 
 Gemini is a tool for searching for similar 'items' in source code repositories.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   lazy val scalapbGrpc = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % "0.8.4"
   lazy val ioGrpc = "io.grpc" % "grpc-netty" % "1.10.0"
   lazy val commonsMath = "org.apache.commons" % "commons-math3" % "3.6.1"
-  lazy val bblfshClient = "org.bblfsh" % "bblfsh-client" % "1.8.2"
+  lazy val bblfshClient = "org.bblfsh" % "bblfsh-client" % "1.10.1"
   lazy val scalaJsonParser = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
   lazy val gcs = "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop2-1.9.11"
   lazy val enry = "tech.sourced" % "enry-java" % "1.7.1"

--- a/src/main/scala/tech/sourced/gemini/cmd/QueryApp.scala
+++ b/src/main/scala/tech/sourced/gemini/cmd/QueryApp.scala
@@ -92,7 +92,7 @@ object QueryApp extends App {
       gemini.applySchema(cassandra)
 
       log.info("Setting up bblfsh/fe gRPC clients")
-      val bblfshClient = BblfshClient.apply(config.bblfshHost, config.bblfshPort)
+      val bblfshClient = BblfshClient(config.bblfshHost, config.bblfshPort)
       val channel = ManagedChannelBuilder.forAddress(config.feHost, config.fePort).usePlaintext(true).build()
       val feClient = FeatureExtractorGrpc.stub(channel)
       val QueryResult(duplicates, similar) =

--- a/src/test/scala/tech/sourced/gemini/FileQuerySpec.scala
+++ b/src/test/scala/tech/sourced/gemini/FileQuerySpec.scala
@@ -81,7 +81,7 @@ class FileQuerySpec extends FlatSpec
     duplicates.head.repo should be("null/Users/alex/src-d/gemini")
     duplicates.head.commit should be("4aa29ac236c55ebbfbef149fef7054d25832717f")
     channel.shutdownNow()
-    //TODO(bzz): bblfshClient.shutdownNow() after https://github.com/bblfsh/client-scala/issues/71
+    bblfshClient.close()
   }
 
   /**


### PR DESCRIPTION
A drive-by improvement while looking at Gemini usage of bblfsh client - use old bblfsh client version, but the one that exposes `.close()`
